### PR TITLE
Circuit compile and proving key gen enhancements

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -52,6 +52,7 @@ jobs:
 
       - name: Build circuits
         env:
+          CIRCUITS_ROOT: ${{ runner.temp }}/zeto-artifacts
           PROVING_KEYS_ROOT: ${{ runner.temp }}/zeto-artifacts
           PTAU_DOWNLOAD_PATH: ${{ runner.temp }}/zeto-artifacts
         working-directory: zkp/circuits
@@ -62,7 +63,7 @@ jobs:
       - name: Run golang e2e tests
         env:
           PROVING_KEYS_ROOT: ${{ runner.temp }}/zeto-artifacts
-          CIRCUITS_ROOT: ${{ github.workspace }}/zkp/js/lib
+          CIRCUITS_ROOT: ${{ runner.temp }}/zeto-artifacts
         working-directory: go-sdk
         run: |
           make e2e
@@ -70,7 +71,7 @@ jobs:
       - name: Run js e2e tests
         env:
           PROVING_KEYS_ROOT: ${{ runner.temp }}/zeto-artifacts
-          CIRCUITS_ROOT: ${{ github.workspace }}/zkp/js/lib
+          CIRCUITS_ROOT: ${{ runner.temp }}/zeto-artifacts
         working-directory: zkp/js
         run: |
           npm install
@@ -79,7 +80,7 @@ jobs:
       - name: Run Zeto Tokens hardhat tests
         env:
           PROVING_KEYS_ROOT: ${{ runner.temp }}/zeto-artifacts
-          CIRCUITS_ROOT: ${{ github.workspace }}/zkp/js/lib
+          CIRCUITS_ROOT: ${{ runner.temp }}/zeto-artifacts
         working-directory: solidity
         run: |
           npm install

--- a/go-sdk/Makefile
+++ b/go-sdk/Makefile
@@ -11,7 +11,7 @@ GOGC=30
 
 all: test go-mod-tidy
 test: deps lint
-		$(VGO) test ./internal/... ./pkg/... -cover -coverprofile=coverage.txt -covermode=atomic -timeout=30s ${TEST_ARGS}
+		$(VGO) test ./internal/... -cover -coverprofile=coverage.txt -covermode=atomic -timeout=30s ${TEST_ARGS}
 coverage.html:
 		$(VGO) tool cover -html=coverage.txt
 coverage: test coverage.html

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/hyperledger-labs/zeto
 
 go 1.22.5
-
-replace github.com/hyperledger-labs/zeto/go-sdk v0.0.0 => ./zkp/golang

--- a/solidity/test/zeto_anon_enc_nullifier.ts
+++ b/solidity/test/zeto_anon_enc_nullifier.ts
@@ -280,10 +280,6 @@ describe("Zeto based fungible token with anonymity using nullifiers and encrypti
     utxo7 = newUTXO(15, Bob);
 
     await expect(doTransfer(Alice, [nonExisting1, nonExisting2], [nullifier1, nullifier2], [utxo7, _utxo1], root.bigInt(), merkleProofs, [Bob, Charlie])).rejectedWith("UTXORootNotFound");
-
-    // clean up the fake UTXOs from the local SMT
-    await smtAlice.delete(nonExisting1.hash);
-    await smtAlice.delete(nonExisting2.hash);
   }).timeout(600000);
 
   async function doTransfer(signer: User, inputs: UTXO[], _nullifiers: UTXO[], outputs: UTXO[], root: BigInt, merkleProofs: BigInt[][], owners: User[]) {

--- a/solidity/test/zeto_anon_nullifier.ts
+++ b/solidity/test/zeto_anon_nullifier.ts
@@ -281,10 +281,6 @@ describe("Zeto based fungible token with anonymity using nullifiers without encr
     utxo7 = newUTXO(15, Bob);
 
     await expect(doTransfer(Alice, [nonExisting1, nonExisting2], [nullifier1, nullifier2], [utxo7, _utxo1], root.bigInt(), merkleProofs, [Bob, Charlie])).rejectedWith("UTXORootNotFound");
-
-    // clean up the fake UTXOs from the local SMT
-    await smtAlice.delete(nonExisting1.hash);
-    await smtAlice.delete(nonExisting2.hash);
   }).timeout(600000);
 
   async function doTransfer(signer: User, inputs: UTXO[], _nullifiers: UTXO[], outputs: UTXO[], root: BigInt, merkleProofs: BigInt[][], owners: User[]) {

--- a/solidity/test/zeto_nf_anon_nullifier.ts
+++ b/solidity/test/zeto_nf_anon_nullifier.ts
@@ -182,9 +182,6 @@ describe("Zeto based non-fungible token with anonymity using nullifiers without 
     const _utxo1 = newAssetUTXO(nonExisting1.tokenId!, nonExisting1.uri!, Charlie);
 
     await expect(doTransfer(Alice, nonExisting1, nullifier1, _utxo1, root.bigInt(), merkleProof, Charlie)).rejectedWith("UTXORootNotFound");
-
-    // clean up the fake UTXOs from the local SMT
-    await smtAlice.delete(nonExisting1.hash);
   }).timeout(600000);
 
   async function doTransfer(signer: User, input: UTXO, _nullifier: UTXO, output: UTXO, root: BigInt, merkleProof: BigInt[], owner: User) {

--- a/zkp/circuits/gen-config.json
+++ b/zkp/circuits/gen-config.json
@@ -39,10 +39,6 @@
     "ptau": "powersOfTau28_hez_final_16",
     "skipSolidityGenaration": false
   },
-  "check_smt_proof": {
-    "ptau": "powersOfTau28_hez_final_16",
-    "skipSolidityGenaration": false
-  },
   "check_nullifiers": {
     "ptau": "powersOfTau28_hez_final_11",
     "skipSolidityGenaration": true

--- a/zkp/circuits/gen.js
+++ b/zkp/circuits/gen.js
@@ -14,8 +14,6 @@ const specificCircuits = argv.c;
 const compileOnly = argv.compileOnly;
 const parallelLimit = parseInt(process.env.GEN_CONCURRENCY, 10) || 10; // Default to compile 10 circuits in parallel
 
-console.log(argv);
-
 // check env vars
 if (!circuitsRoot) {
   console.error('Error: CIRCUITS_ROOT is not set.');

--- a/zkp/circuits/gen.js
+++ b/zkp/circuits/gen.js
@@ -14,6 +14,8 @@ const specificCircuits = argv.c;
 const compileOnly = argv.compileOnly;
 const parallelLimit = parseInt(process.env.GEN_CONCURRENCY, 10) || 10; // Default to compile 10 circuits in parallel
 
+console.log(argv);
+
 // check env vars
 if (!circuitsRoot) {
   console.error('Error: CIRCUITS_ROOT is not set.');
@@ -114,8 +116,8 @@ const processCircuit = async (circuit, ptau, skipSolidityGenaration) => {
 };
 
 const run = async () => {
+  let onlyCircuits = specificCircuits;
   if (specificCircuits) {
-    let onlyCircuits = specificCircuits;
     if (!Array.isArray(specificCircuits)) {
       onlyCircuits = [specificCircuits];
     }
@@ -133,7 +135,7 @@ const run = async () => {
   const activePromises = new Set();
 
   for (const [circuit, { ptau, skipSolidityGenaration }] of circuitsArray) {
-    if (specificCircuits && !specificCircuits.includes(circuit)) {
+    if (onlyCircuits && !onlyCircuits.includes(circuit)) {
       continue;
     }
 

--- a/zkp/circuits/gen.js
+++ b/zkp/circuits/gen.js
@@ -7,9 +7,9 @@ const yargs = require('yargs/yargs');
 const { hideBin } = require('yargs/helpers');
 const argv = yargs(hideBin(process.argv)).argv;
 
-const circuitsRoot = process.env.CIRCUITS_ROOT;
-const provingKeysRoot = process.env.PROVING_KEYS_ROOT;
-const ptauDownload = process.env.PTAU_DOWNLOAD_PATH;
+const circuitsRoot = process.env.CIRCUITS_ROOT || argv.circuitsRoot;
+const provingKeysRoot = process.env.PROVING_KEYS_ROOT || argv.provingKeysRoot;
+const ptauDownload = process.env.PTAU_DOWNLOAD_PATH || argv.ptauDownloadPath;
 const specificCircuits = argv.c;
 const compileOnly = argv.compileOnly;
 const parallelLimit = parseInt(process.env.GEN_CONCURRENCY, 10) || 10; // Default to compile 10 circuits in parallel
@@ -115,8 +115,13 @@ const processCircuit = async (circuit, ptau, skipSolidityGenaration) => {
 
 const run = async () => {
   if (specificCircuits) {
+    let onlyCircuits = specificCircuits;
+    if (!Array.isArray(specificCircuits)) {
+      onlyCircuits = [specificCircuits];
+    }
+
     // if specific circuits are provided, check it's in the map
-    for (const circuit of specificCircuits) {
+    for (const circuit of onlyCircuits) {
       if (!circuits[circuit]) {
         console.error(`Error: Unknown circuit: ${circuit}`);
         process.exit(1);

--- a/zkp/circuits/package.json
+++ b/zkp/circuits/package.json
@@ -4,14 +4,14 @@
   "description": "Circom library for ZK circuits for use with Zeto based privacy-preserving tokens",
   "license": "Apache-2.0",
   "dependencies": {
-    "circomlib": "^2.0.5",
-    "yargs": "^17.7.2"
+    "circomlib": "^2.0.5"
   },
   "scripts": {
     "gen": "node gen.js"
   },
   "devDependencies": {
     "axios": "^1.7.3",
-    "p-limit": "^6.1.0"
+    "p-limit": "^6.1.0",
+    "yargs": "^17.7.2"
   }
 }

--- a/zkp/circuits/package.json
+++ b/zkp/circuits/package.json
@@ -4,7 +4,8 @@
   "description": "Circom library for ZK circuits for use with Zeto based privacy-preserving tokens",
   "license": "Apache-2.0",
   "dependencies": {
-    "circomlib": "^2.0.5"
+    "circomlib": "^2.0.5",
+    "yargs": "^17.7.2"
   },
   "scripts": {
     "gen": "node gen.js"

--- a/zkp/js/README.md
+++ b/zkp/js/README.md
@@ -32,13 +32,13 @@ npm i
   export CIRCUITS_ROOT="$HOME/circuits"
   export PROVING_KEYS_ROOT="$HOME/proving-keys"
   export PTAU_DOWNLOAD_PATH="$HOME/Downloads"
-  mkdir -p $PROVING_KEYS_ROOT $PTAU_DOWNLOAD_PATH
+  mkdir -p $PROVING_KEYS_ROOT $PTAU_DOWNLOAD_PATH $CIRCUITS_ROOT
   ```
 - run the generation script for **ALL** circuits
   ```console
   npm run gen
   ```
-  **run `npm run gen $circuit` for developing a single circuit**
+  **run `npm run gen -- -c $circuit` for developing a single circuit**
   **use `GEN_CONCURRENCY` to control how many circuits to be processed in parallel, default to 10**
 
 > Refer to [generation script explanation](#generation-script-explanation) for what the script does

--- a/zkp/js/README.md
+++ b/zkp/js/README.md
@@ -29,6 +29,7 @@ npm i
 
 - set where you want to store the generated verification keys and the downloaded PTAU files
   ```console
+  export CIRCUITS_ROOT="$HOME/circuits"
   export PROVING_KEYS_ROOT="$HOME/proving-keys"
   export PTAU_DOWNLOAD_PATH="$HOME/Downloads"
   mkdir -p $PROVING_KEYS_ROOT $PTAU_DOWNLOAD_PATH

--- a/zkp/js/index.js
+++ b/zkp/js/index.js
@@ -23,8 +23,12 @@ function loadCircuit(type) {
   if (!type) {
     throw new Error('The circuit name must be provided');
   }
-  const WitnessCalculator = require(`./lib/${type}_js/witness_calculator.js`);
-  const buffer = readFileSync(path.join(__dirname, `./lib/${type}_js/${type}.wasm`));
+  const circuitsRoot = process.env.CIRCUITS_ROOT;
+  if (!circuitsRoot) {
+    throw new Error('CIRCUITS_ROOT is not set');
+  }
+  const WitnessCalculator = require(path.join(circuitsRoot, `${type}_js/witness_calculator.js`));
+  const buffer = readFileSync(path.join(circuitsRoot, `${type}_js/${type}.wasm`));
   return WitnessCalculator(buffer);
 }
 


### PR DESCRIPTION
- allow multiple circuits to be specified: `-c anon -c anon_nullifier`
- allow compile only without generating the proving keys
- update the js library to require `CIRCUITS_ROOT` rather than always assuming the circuit WASM to be in the local lib folder