### PR TITLE
Change CommonLib functions to 'internal'

### DIFF
--- a/solidity/contracts/lib/common.sol
+++ b/solidity/contracts/lib/common.sol
@@ -25,7 +25,9 @@ library Commonlib {
         uint[2] pC;
     }
 
-    function getProofHash(Proof calldata proof) public pure returns (bytes32) {
+    function getProofHash(
+        Proof calldata proof
+    ) internal pure returns (bytes32) {
         uint[8] memory inputs = [
             proof.pA[0],
             proof.pA[1],
@@ -44,7 +46,7 @@ library Commonlib {
     // until it's available in a new release
     function sort(
         uint256[] memory array
-    ) public pure returns (uint256[] memory) {
+    ) internal pure returns (uint256[] memory) {
         bytes32[] memory bytes32Array = _castToBytes32Array(array);
         _quickSort(_begin(bytes32Array), _end(bytes32Array), _defaultComp);
         return array;

--- a/solidity/ignition/modules/zeto_anon.ts
+++ b/solidity/ignition/modules/zeto_anon.ts
@@ -26,13 +26,8 @@ export default buildModule("Zeto_Anon", (m) => {
   const { verifier } = m.useModule(VerifierModule);
   const { verifier: depositVerifier } = m.useModule(DepositVerifierModule);
   const { verifier: withdrawVerifier } = m.useModule(WithdrawVerifierModule);
-  const commonlib = m.library('Commonlib');
 
-  const zeto = m.contract('Zeto_Anon', [depositVerifier, withdrawVerifier, verifier], {
-    libraries: {
-      Commonlib: commonlib,
-    },
-  });
+  const zeto = m.contract('Zeto_Anon', [depositVerifier, withdrawVerifier, verifier]);
 
   return { zeto };
 });

--- a/solidity/ignition/modules/zeto_anon_enc.ts
+++ b/solidity/ignition/modules/zeto_anon_enc.ts
@@ -26,13 +26,8 @@ export default buildModule("Zeto_AnonEnc", (m) => {
   const { verifier } = m.useModule(VerifierModule);
   const { verifier: depositVerifier } = m.useModule(DepositVerifierModule);
   const { verifier: withdrawVerifier } = m.useModule(WithdrawVerifierModule);
-  const commonlib = m.library('Commonlib');
 
-  const zeto = m.contract('Zeto_AnonEnc', [depositVerifier, withdrawVerifier, verifier], {
-    libraries: {
-      Commonlib: commonlib,
-    },
-  });
+  const zeto = m.contract('Zeto_AnonEnc', [depositVerifier, withdrawVerifier, verifier]);
 
   return { zeto };
 });

--- a/solidity/ignition/modules/zeto_anon_enc_nullifier.ts
+++ b/solidity/ignition/modules/zeto_anon_enc_nullifier.ts
@@ -27,13 +27,11 @@ export default buildModule("Zeto_AnonEncNullifier", (m) => {
   const { verifier } = m.useModule(VerifierModule);
   const { verifier: depositVerifier } = m.useModule(DepositVerifierModule);
   const { verifier: withdrawVerifier } = m.useModule(WithdrawNullifierVerifierModule);
-  const commonlib = m.library('Commonlib');
 
   const zeto = m.contract('Zeto_AnonEncNullifier', [depositVerifier, withdrawVerifier, verifier], {
     libraries: {
       SmtLib: smtLib,
       PoseidonUnit3L: poseidon3,
-      Commonlib: commonlib,
     },
   });
 

--- a/solidity/ignition/modules/zeto_anon_enc_nullifier_non_repudiation.ts
+++ b/solidity/ignition/modules/zeto_anon_enc_nullifier_non_repudiation.ts
@@ -27,13 +27,11 @@ export default buildModule("Zeto_AnonEncNullifierNonRepudiation", (m) => {
   const { verifier } = m.useModule(VerifierModule);
   const { verifier: depositVerifier } = m.useModule(DepositVerifierModule);
   const { verifier: withdrawVerifier } = m.useModule(WithdrawNullifierVerifierModule);
-  const commonlib = m.library('Commonlib');
 
   const zeto = m.contract('Zeto_AnonEncNullifierNonRepudiation', [depositVerifier, withdrawVerifier, verifier], {
     libraries: {
       SmtLib: smtLib,
       PoseidonUnit3L: poseidon3,
-      Commonlib: commonlib,
     },
   });
 

--- a/solidity/ignition/modules/zeto_anon_nullifier.ts
+++ b/solidity/ignition/modules/zeto_anon_nullifier.ts
@@ -27,13 +27,11 @@ export default buildModule("Zeto_AnonNullifier", (m) => {
   const { verifier } = m.useModule(VerifierModule);
   const { verifier: depositVerifier } = m.useModule(DepositVerifierModule);
   const { verifier: withdrawVerifier } = m.useModule(WithdrawNullifierVerifierModule);
-  const commonlib = m.library('Commonlib');
 
   const zeto = m.contract('Zeto_AnonNullifier', [depositVerifier, withdrawVerifier, verifier], {
     libraries: {
       SmtLib: smtLib,
       PoseidonUnit3L: poseidon3,
-      Commonlib: commonlib,
     },
   });
 

--- a/solidity/ignition/modules/zeto_anon_nullifier_kyc.ts
+++ b/solidity/ignition/modules/zeto_anon_nullifier_kyc.ts
@@ -27,14 +27,12 @@ export default buildModule("Zeto_AnonNullifierKyc", (m) => {
   const { verifier } = m.useModule(VerifierModule);
   const { verifier: depositVerifier } = m.useModule(DepositVerifierModule);
   const { verifier: withdrawVerifier } = m.useModule(WithdrawNullifierVerifierModule);
-  const commonlib = m.library('Commonlib');
 
   const zeto = m.contract('Zeto_AnonNullifierKyc', [depositVerifier, withdrawVerifier, verifier], {
     libraries: {
       SmtLib: smtLib,
       PoseidonUnit2L: poseidon2,
       PoseidonUnit3L: poseidon3,
-      Commonlib: commonlib,
     },
   });
 

--- a/solidity/ignition/modules/zeto_nf_anon.ts
+++ b/solidity/ignition/modules/zeto_nf_anon.ts
@@ -23,13 +23,8 @@ const VerifierModule = buildModule("Groth16Verifier_NfAnon", (m) => {
 
 export default buildModule("Zeto_NfAnon", (m) => {
   const { verifier } = m.useModule(VerifierModule);
-  const commonlib = m.library('Commonlib');
 
-  const zeto = m.contract('Zeto_NfAnon', [verifier], {
-    libraries: {
-      Commonlib: commonlib,
-    },
-  });
+  const zeto = m.contract('Zeto_NfAnon', [verifier]);
 
   return { zeto };
 });

--- a/solidity/ignition/modules/zeto_nf_anon_nullifier.ts
+++ b/solidity/ignition/modules/zeto_nf_anon_nullifier.ts
@@ -25,13 +25,11 @@ const VerifierModule = buildModule("Groth16Verifier_NfAnonNullifier", (m) => {
 export default buildModule("Zeto_NfAnonNullifier", (m) => {
   const { smtLib, poseidon3 } = m.useModule(SmtLibModule);
   const { verifier } = m.useModule(VerifierModule);
-  const commonlib = m.library('Commonlib');
 
   const zeto = m.contract('Zeto_NfAnonNullifier', [verifier], {
     libraries: {
       SmtLib: smtLib,
       PoseidonUnit3L: poseidon3,
-      Commonlib: commonlib,
     },
   });
 


### PR DESCRIPTION
For the small code size of the CommonLib, it can be included in the main contract.