### PR TITLE
Fix handling of 0 input elements in nullifier token mints

### DIFF
--- a/solidity/contracts/lib/zeto_nullifier.sol
+++ b/solidity/contracts/lib/zeto_nullifier.sol
@@ -113,6 +113,9 @@ abstract contract ZetoNullifier is ZetoCommon {
     function _mint(uint256[] memory utxos) internal virtual {
         for (uint256 i = 0; i < utxos.length; ++i) {
             uint256 utxo = utxos[i];
+            if (utxo == 0) {
+                continue;
+            }
             uint256 nodeHash = _getLeafNodeHash(utxo);
             SmtLib.Node memory node = _commitmentsTree.getNode(nodeHash);
 

--- a/solidity/test/zeto_anon_enc_nullifier.ts
+++ b/solidity/test/zeto_anon_enc_nullifier.ts
@@ -134,7 +134,7 @@ describe("Zeto based fungible token with anonymity using nullifiers and encrypti
     // check the private transfer activity is not exposed in the ERC20 contract
     const afterTransferBalance = await erc20.balanceOf(Alice.ethAddress);
     expect(afterTransferBalance).to.equal(startingBalance);
-  
+
     // Alice locally tracks the UTXOs inside the Sparse Merkle Tree
     await smtAlice.add(_utxo3.hash, _utxo3.hash);
     await smtAlice.add(utxo4.hash, utxo4.hash);
@@ -326,6 +326,13 @@ describe("Zeto based fungible token with anonymity using nullifiers and encrypti
 
       await expect(doTransfer(Alice, [nonExisting1, nonExisting2], [nullifier1, nullifier2], [utxo7, _utxo1], root.bigInt(), merkleProofs, [Bob, Charlie])).rejectedWith("UTXORootNotFound");
     }).timeout(600000);
+
+    it("repeated mint calls with single UTXO should not fail", async function () {
+      const utxo5 = newUTXO(10, Alice);
+      await expect(doMint(zeto, deployer, [utxo5, ZERO_UTXO])).fulfilled;
+      const utxo6 = newUTXO(20, Alice);
+      await expect(doMint(zeto, deployer, [utxo6, ZERO_UTXO])).fulfilled;
+    });
   });
 
   async function doTransfer(signer: User, inputs: UTXO[], _nullifiers: UTXO[], outputs: UTXO[], root: BigInt, merkleProofs: BigInt[][], owners: User[]) {

--- a/solidity/test/zeto_anon_nullifier.ts
+++ b/solidity/test/zeto_anon_nullifier.ts
@@ -327,6 +327,13 @@ describe("Zeto based fungible token with anonymity using nullifiers without encr
 
       await expect(doTransfer(Alice, [nonExisting1, nonExisting2], [nullifier1, nullifier2], [utxo7, _utxo1], root.bigInt(), merkleProofs, [Bob, Charlie])).rejectedWith("UTXORootNotFound");
     }).timeout(600000);
+
+    it("repeated mint calls with single UTXO should not fail", async function () {
+      const utxo5 = newUTXO(10, Alice);
+      await expect(doMint(zeto, deployer, [utxo5, ZERO_UTXO])).fulfilled;
+      const utxo6 = newUTXO(20, Alice);
+      await expect(doMint(zeto, deployer, [utxo6, ZERO_UTXO])).fulfilled;
+    });
   });
 
   async function doTransfer(signer: User, inputs: UTXO[], _nullifiers: UTXO[], outputs: UTXO[], root: BigInt, merkleProofs: BigInt[][], owners: User[]) {

--- a/solidity/test/zeto_anon_nullifier_kyc.ts
+++ b/solidity/test/zeto_anon_nullifier_kyc.ts
@@ -496,6 +496,13 @@ describe("Zeto based fungible token with anonymity, KYC, using nullifiers withou
 
       await expect(doTransfer(Alice, [nonExisting1, nonExisting2], [nullifier1, nullifier2], [utxo7, _utxo1], root.bigInt(), merkleProofs, identitiesRoot.bigInt(), identitiesMerkleProofs, [Bob, Charlie])).rejectedWith("UTXORootNotFound");
     }).timeout(600000);
+
+    it("repeated mint calls with single UTXO should not fail", async function () {
+      const utxo5 = newUTXO(10, Alice);
+      await expect(doMint(zeto, deployer, [utxo5, ZERO_UTXO])).fulfilled;
+      const utxo6 = newUTXO(20, Alice);
+      await expect(doMint(zeto, deployer, [utxo6, ZERO_UTXO])).fulfilled;
+    });
   });
 
   async function doTransfer(signer: User, inputs: UTXO[], _nullifiers: UTXO[], outputs: UTXO[], utxosRoot: BigInt, utxosMerkleProofs: BigInt[][], identitiesRoot: BigInt, identitiesMerkleProof: BigInt[][], owners: User[]) {


### PR DESCRIPTION
Before the fix, calling `mint()` with inputs that contain `0` UTXOs repeatedly with fail, because the solidity code adds the zeto node to the tree and fails the existence checks