### PR TITLE
Add "data" parameter to all mint/transfer methods

### DIFF
--- a/solidity/contracts/erc20.sol
+++ b/solidity/contracts/erc20.sol
@@ -17,7 +17,6 @@ pragma solidity ^0.8.20;
 
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import "hardhat/console.sol";
 
 /// @title A sample implementation of a Zeto based fungible token with anonymity and no encryption
 /// @author Kaleido, Inc.

--- a/solidity/contracts/lib/interfaces/izeto.sol
+++ b/solidity/contracts/lib/interfaces/izeto.sol
@@ -21,6 +21,7 @@ interface IZeto is IZetoBase {
     event UTXOTransfer(
         uint256[] inputs,
         uint256[] outputs,
-        address indexed submitter
+        address indexed submitter,
+        bytes data
     );
 }

--- a/solidity/contracts/lib/interfaces/izeto.sol
+++ b/solidity/contracts/lib/interfaces/izeto.sol
@@ -1,0 +1,26 @@
+// Copyright © 2024 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+pragma solidity ^0.8.20;
+
+import {IZetoBase} from "./izeto_base.sol";
+
+interface IZeto is IZetoBase {
+    event UTXOTransfer(
+        uint256[] inputs,
+        uint256[] outputs,
+        address indexed submitter
+    );
+}

--- a/solidity/contracts/lib/interfaces/izeto_base.sol
+++ b/solidity/contracts/lib/interfaces/izeto_base.sol
@@ -16,5 +16,5 @@
 pragma solidity ^0.8.20;
 
 interface IZetoBase {
-    event UTXOMint(uint256[] outputs, address indexed submitter);
+    event UTXOMint(uint256[] outputs, address indexed submitter, bytes data);
 }

--- a/solidity/contracts/lib/interfaces/izeto_base.sol
+++ b/solidity/contracts/lib/interfaces/izeto_base.sol
@@ -1,0 +1,20 @@
+// Copyright © 2024 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+pragma solidity ^0.8.20;
+
+interface IZetoBase {
+    event UTXOMint(uint256[] outputs, address indexed submitter);
+}

--- a/solidity/contracts/lib/interfaces/izeto_encrypted.sol
+++ b/solidity/contracts/lib/interfaces/izeto_encrypted.sol
@@ -23,6 +23,7 @@ interface IZetoEncrypted is IZetoBase {
         uint256[] outputs,
         uint256 encryptionNonce,
         uint256[] encryptedValues,
-        address indexed submitter
+        address indexed submitter,
+        bytes data
     );
 }

--- a/solidity/contracts/lib/interfaces/izeto_encrypted.sol
+++ b/solidity/contracts/lib/interfaces/izeto_encrypted.sol
@@ -1,0 +1,28 @@
+// Copyright © 2024 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+pragma solidity ^0.8.20;
+
+import {IZetoBase} from "./izeto_base.sol";
+
+interface IZetoEncrypted is IZetoBase {
+    event UTXOTransferWithEncryptedValues(
+        uint256[] inputs,
+        uint256[] outputs,
+        uint256 encryptionNonce,
+        uint256[] encryptedValues,
+        address indexed submitter
+    );
+}

--- a/solidity/contracts/lib/registry.sol
+++ b/solidity/contracts/lib/registry.sol
@@ -19,7 +19,6 @@ import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Own
 import {SmtLib} from "@iden3/contracts/lib/SmtLib.sol";
 import {PoseidonUnit2L, PoseidonUnit3L} from "@iden3/contracts/lib/Poseidon.sol";
 import {Commonlib} from "./common.sol";
-import "hardhat/console.sol";
 
 uint256 constant MAX_SMT_DEPTH = 64;
 

--- a/solidity/contracts/lib/zeto_base.sol
+++ b/solidity/contracts/lib/zeto_base.sol
@@ -115,7 +115,7 @@ abstract contract ZetoBase is IZetoBase, ZetoCommon {
 
     // This function is used to mint new UTXOs, as an example implementation,
     // which is only callable by the owner.
-    function _mint(uint256[] memory utxos) internal virtual {
+    function _mint(uint256[] memory utxos, bytes calldata data) internal virtual {
         for (uint256 i = 0; i < utxos.length; ++i) {
             uint256 utxo = utxos[i];
             if (_utxos[utxo] == UTXOStatus.UNSPENT) {
@@ -126,6 +126,6 @@ abstract contract ZetoBase is IZetoBase, ZetoCommon {
 
             _utxos[utxo] = UTXOStatus.UNSPENT;
         }
-        emit UTXOMint(utxos, msg.sender);
+        emit UTXOMint(utxos, msg.sender, data);
     }
 }

--- a/solidity/contracts/lib/zeto_base.sol
+++ b/solidity/contracts/lib/zeto_base.sol
@@ -15,6 +15,7 @@
 // limitations under the License.
 pragma solidity ^0.8.20;
 
+import {IZetoBase} from "./interfaces/izeto_base.sol";
 import {Commonlib} from "./common.sol";
 import {Registry} from "./registry.sol";
 import {ZetoCommon} from "./zeto_common.sol";
@@ -25,7 +26,7 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 ///        without using nullifiers. Each UTXO's spending status is explicitly tracked.
 /// @author Kaleido, Inc.
 /// @dev Implements common functionalities of Zeto based tokens without nullifiers
-abstract contract ZetoBase is ZetoCommon {
+abstract contract ZetoBase is IZetoBase, ZetoCommon {
     enum UTXOStatus {
         UNKNOWN, // default value for the empty UTXO slots
         UNSPENT,

--- a/solidity/contracts/lib/zeto_common.sol
+++ b/solidity/contracts/lib/zeto_common.sol
@@ -23,22 +23,6 @@ import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Own
 /// @author Kaleido, Inc.
 /// @dev Implements common functionalities of Zeto based tokens
 abstract contract ZetoCommon is OwnableUpgradeable {
-    event UTXOMint(uint256[] outputs, address indexed submitter);
-
-    event UTXOTransfer(
-        uint256[] inputs,
-        uint256[] outputs,
-        address indexed submitter
-    );
-
-    event UTXOTransferWithEncryptedValues(
-        uint256[] inputs,
-        uint256[] outputs,
-        uint256 encryptionNonce,
-        uint256[] encryptedValues,
-        address indexed submitter
-    );
-
     error UTXONotMinted(uint256 utxo);
     error UTXOAlreadyOwned(uint256 utxo);
     error UTXOAlreadySpent(uint256 utxo);

--- a/solidity/contracts/lib/zeto_nullifier.sol
+++ b/solidity/contracts/lib/zeto_nullifier.sol
@@ -111,7 +111,7 @@ abstract contract ZetoNullifier is IZetoBase, ZetoCommon {
 
     // This function is used to mint new UTXOs, as an example implementation,
     // which is only callable by the owner.
-    function _mint(uint256[] memory utxos) internal virtual {
+    function _mint(uint256[] memory utxos, bytes calldata data) internal virtual {
         for (uint256 i = 0; i < utxos.length; ++i) {
             uint256 utxo = utxos[i];
             if (utxo == 0) {
@@ -127,7 +127,7 @@ abstract contract ZetoNullifier is IZetoBase, ZetoCommon {
             _commitmentsTree.addLeaf(utxo, utxo);
         }
 
-        emit UTXOMint(utxos, msg.sender);
+        emit UTXOMint(utxos, msg.sender, data);
     }
 
     function getRoot() public view returns (uint256) {

--- a/solidity/contracts/lib/zeto_nullifier.sol
+++ b/solidity/contracts/lib/zeto_nullifier.sol
@@ -15,6 +15,7 @@
 // limitations under the License.
 pragma solidity ^0.8.20;
 
+import {IZetoBase} from "./interfaces/izeto_base.sol";
 import {Commonlib} from "./common.sol";
 import {Registry} from "./registry.sol";
 import {ZetoCommon} from "./zeto_common.sol";
@@ -27,7 +28,7 @@ uint256 constant MAX_SMT_DEPTH = 64;
 /// @title A sample base implementation of a Zeto based token contract with nullifiers
 /// @author Kaleido, Inc.
 /// @dev Implements common functionalities of Zeto based tokens using nullifiers
-abstract contract ZetoNullifier is ZetoCommon {
+abstract contract ZetoNullifier is IZetoBase, ZetoCommon {
     SmtLib.Data internal _commitmentsTree;
     using SmtLib for SmtLib.Data;
     mapping(uint256 => bool) private _nullifiers;

--- a/solidity/contracts/zeto_anon.sol
+++ b/solidity/contracts/zeto_anon.sol
@@ -99,12 +99,13 @@ contract Zeto_Anon is IZeto, ZetoBase, ZetoFungibleWithdraw, UUPSUpgradeable {
     function deposit(
         uint256 amount,
         uint256 utxo,
-        Commonlib.Proof calldata proof
+        Commonlib.Proof calldata proof,
+        bytes calldata data
     ) public {
         _deposit(amount, utxo, proof);
         uint256[] memory utxos = new uint256[](1);
         utxos[0] = utxo;
-        _mint(utxos);
+        _mint(utxos, data);
     }
 
     function withdraw(
@@ -118,7 +119,7 @@ contract Zeto_Anon is IZeto, ZetoBase, ZetoFungibleWithdraw, UUPSUpgradeable {
         processInputsAndOutputs(inputs, [output, 0]);
     }
 
-    function mint(uint256[] memory utxos) public onlyOwner {
-        _mint(utxos);
+    function mint(uint256[] memory utxos, bytes calldata data) public onlyOwner {
+        _mint(utxos, data);
     }
 }

--- a/solidity/contracts/zeto_anon.sol
+++ b/solidity/contracts/zeto_anon.sol
@@ -15,6 +15,7 @@
 // limitations under the License.
 pragma solidity ^0.8.20;
 
+import {IZeto} from "./lib/interfaces/izeto.sol";
 import {Groth16Verifier_CheckHashesValue} from "./lib/verifier_check_hashes_value.sol";
 import {Groth16Verifier_CheckInputsOutputsValue} from "./lib/verifier_check_inputs_outputs_value.sol";
 import {Groth16Verifier_Anon} from "./lib/verifier_anon.sol";
@@ -34,7 +35,7 @@ import "hardhat/console.sol";
 ///        - the sum of the input values match the sum of output values
 ///        - the hashes in the input and output match the `hash(value, salt, owner public key)` formula
 ///        - the sender possesses the private BabyJubjub key, whose public key is part of the pre-image of the input commitment hashes
-contract Zeto_Anon is ZetoBase, ZetoFungibleWithdraw, UUPSUpgradeable {
+contract Zeto_Anon is IZeto, ZetoBase, ZetoFungibleWithdraw, UUPSUpgradeable {
     Groth16Verifier_Anon internal verifier;
 
     function initialize(

--- a/solidity/contracts/zeto_anon.sol
+++ b/solidity/contracts/zeto_anon.sol
@@ -26,7 +26,6 @@ import {ZetoFungible} from "./lib/zeto_fungible.sol";
 import {ZetoFungibleWithdraw} from "./lib/zeto_fungible_withdraw.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
-import "hardhat/console.sol";
 
 /// @title A sample implementation of a Zeto based fungible token with anonymity and no encryption
 /// @author Kaleido, Inc.

--- a/solidity/contracts/zeto_anon.sol
+++ b/solidity/contracts/zeto_anon.sol
@@ -63,7 +63,8 @@ contract Zeto_Anon is IZeto, ZetoBase, ZetoFungibleWithdraw, UUPSUpgradeable {
     function transfer(
         uint256[2] memory inputs,
         uint256[2] memory outputs,
-        Commonlib.Proof calldata proof
+        Commonlib.Proof calldata proof,
+        bytes calldata data
     ) public returns (bool) {
         require(
             validateTransactionProposal(inputs, outputs, proof),
@@ -91,7 +92,7 @@ contract Zeto_Anon is IZeto, ZetoBase, ZetoFungibleWithdraw, UUPSUpgradeable {
             inputArray[i] = inputs[i];
             outputArray[i] = outputs[i];
         }
-        emit UTXOTransfer(inputArray, outputArray, msg.sender);
+        emit UTXOTransfer(inputArray, outputArray, msg.sender, data);
 
         return true;
     }

--- a/solidity/contracts/zeto_anon_enc.sol
+++ b/solidity/contracts/zeto_anon_enc.sol
@@ -67,7 +67,8 @@ contract Zeto_AnonEnc is IZetoEncrypted, ZetoBase, ZetoFungibleWithdraw, UUPSUpg
         uint256[2] memory outputs,
         uint256 encryptionNonce,
         uint256[4] memory encryptedValues,
-        Commonlib.Proof calldata proof
+        Commonlib.Proof calldata proof,
+        bytes calldata data
     ) public returns (bool) {
         require(
             validateTransactionProposal(inputs, outputs, proof),
@@ -112,7 +113,8 @@ contract Zeto_AnonEnc is IZetoEncrypted, ZetoBase, ZetoFungibleWithdraw, UUPSUpg
             outputArray,
             encryptionNonce,
             encryptedValuesArray,
-            msg.sender
+            msg.sender,
+            data
         );
         return true;
     }

--- a/solidity/contracts/zeto_anon_enc.sol
+++ b/solidity/contracts/zeto_anon_enc.sol
@@ -15,6 +15,7 @@
 // limitations under the License.
 pragma solidity ^0.8.20;
 
+import {IZetoEncrypted} from "./lib/interfaces/izeto_encrypted.sol";
 import {Groth16Verifier_CheckHashesValue} from "./lib/verifier_check_hashes_value.sol";
 import {Groth16Verifier_CheckInputsOutputsValue} from "./lib/verifier_check_inputs_outputs_value.sol";
 import {Groth16Verifier_AnonEnc} from "./lib/verifier_anon_enc.sol";
@@ -36,7 +37,7 @@ import "hardhat/console.sol";
 ///        - the sender possesses the private BabyJubjub key, whose public key is part of the pre-image of the input commitment hashes
 ///        - the encrypted value in the input is derived from the receiver's UTXO value and encrypted with a shared secret using
 ///          the ECDH protocol between the sender and receiver (this guarantees data availability for the receiver)
-contract Zeto_AnonEnc is ZetoBase, ZetoFungibleWithdraw, UUPSUpgradeable {
+contract Zeto_AnonEnc is IZetoEncrypted, ZetoBase, ZetoFungibleWithdraw, UUPSUpgradeable {
     Groth16Verifier_AnonEnc internal verifier;
 
     function initialize(

--- a/solidity/contracts/zeto_anon_enc.sol
+++ b/solidity/contracts/zeto_anon_enc.sol
@@ -26,7 +26,6 @@ import {Registry} from "./lib/registry.sol";
 import {Commonlib} from "./lib/common.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
-import "hardhat/console.sol";
 
 /// @title A sample implementation of a Zeto based fungible token with anonymity, and encryption
 /// @author Kaleido, Inc.

--- a/solidity/contracts/zeto_anon_enc.sol
+++ b/solidity/contracts/zeto_anon_enc.sol
@@ -120,12 +120,13 @@ contract Zeto_AnonEnc is IZetoEncrypted, ZetoBase, ZetoFungibleWithdraw, UUPSUpg
     function deposit(
         uint256 amount,
         uint256 utxo,
-        Commonlib.Proof calldata proof
+        Commonlib.Proof calldata proof,
+        bytes calldata data
     ) public {
         _deposit(amount, utxo, proof);
         uint256[] memory utxos = new uint256[](1);
         utxos[0] = utxo;
-        _mint(utxos);
+        _mint(utxos, data);
     }
 
     function withdraw(
@@ -139,7 +140,7 @@ contract Zeto_AnonEnc is IZetoEncrypted, ZetoBase, ZetoFungibleWithdraw, UUPSUpg
         processInputsAndOutputs(inputs, [output, 0]);
     }
 
-    function mint(uint256[] memory utxos) public onlyOwner {
-        _mint(utxos);
+    function mint(uint256[] memory utxos, bytes calldata data) public onlyOwner {
+        _mint(utxos, data);
     }
 }

--- a/solidity/contracts/zeto_anon_enc_nullifier.sol
+++ b/solidity/contracts/zeto_anon_enc_nullifier.sol
@@ -135,12 +135,13 @@ contract Zeto_AnonEncNullifier is
     function deposit(
         uint256 amount,
         uint256 utxo,
-        Commonlib.Proof calldata proof
+        Commonlib.Proof calldata proof,
+        bytes calldata data
     ) public {
         _deposit(amount, utxo, proof);
         uint256[] memory utxos = new uint256[](1);
         utxos[0] = utxo;
-        _mint(utxos);
+        _mint(utxos, data);
     }
 
     function withdraw(
@@ -155,7 +156,7 @@ contract Zeto_AnonEncNullifier is
         processInputsAndOutputs(nullifiers, [output, 0]);
     }
 
-    function mint(uint256[] memory utxos) public onlyOwner {
-        _mint(utxos);
+    function mint(uint256[] memory utxos, bytes calldata data) public onlyOwner {
+        _mint(utxos, data);
     }
 }

--- a/solidity/contracts/zeto_anon_enc_nullifier.sol
+++ b/solidity/contracts/zeto_anon_enc_nullifier.sol
@@ -78,7 +78,8 @@ contract Zeto_AnonEncNullifier is
         uint256 root,
         uint256 encryptionNonce,
         uint256[4] memory encryptedValues,
-        Commonlib.Proof calldata proof
+        Commonlib.Proof calldata proof,
+        bytes calldata data
     ) public returns (bool) {
         require(
             validateTransactionProposal(nullifiers, outputs, root),
@@ -127,7 +128,8 @@ contract Zeto_AnonEncNullifier is
             outputArray,
             encryptionNonce,
             encryptedValuesArray,
-            msg.sender
+            msg.sender,
+            data
         );
         return true;
     }

--- a/solidity/contracts/zeto_anon_enc_nullifier.sol
+++ b/solidity/contracts/zeto_anon_enc_nullifier.sol
@@ -24,7 +24,6 @@ import {ZetoFungibleWithdrawWithNullifiers} from "./lib/zeto_fungible_withdraw_n
 import {Registry} from "./lib/registry.sol";
 import {Commonlib} from "./lib/common.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
-import "hardhat/console.sol";
 
 /// @title A sample implementation of a Zeto based fungible token with anonymity, encryption and history masking
 /// @author Kaleido, Inc.

--- a/solidity/contracts/zeto_anon_enc_nullifier.sol
+++ b/solidity/contracts/zeto_anon_enc_nullifier.sol
@@ -15,6 +15,7 @@
 // limitations under the License.
 pragma solidity ^0.8.20;
 
+import {IZetoEncrypted} from "./lib/interfaces/izeto_encrypted.sol";
 import {Groth16Verifier_CheckHashesValue} from "./lib/verifier_check_hashes_value.sol";
 import {Groth16Verifier_CheckNullifierValue} from "./lib/verifier_check_nullifier_value.sol";
 import {Groth16Verifier_AnonEncNullifier} from "./lib/verifier_anon_enc_nullifier.sol";
@@ -35,6 +36,7 @@ import "hardhat/console.sol";
 ///        - the encrypted value in the input is derived from the receiver's UTXO value and encrypted with a shared secret using the ECDH protocol between the sender and receiver (this guarantees data availability for the receiver)
 ///        - the nullifiers represent input commitments that are included in a Sparse Merkle Tree represented by the root hash
 contract Zeto_AnonEncNullifier is
+    IZetoEncrypted,
     ZetoNullifier,
     ZetoFungibleWithdrawWithNullifiers,
     UUPSUpgradeable

--- a/solidity/contracts/zeto_anon_enc_nullifier_kyc.sol
+++ b/solidity/contracts/zeto_anon_enc_nullifier_kyc.sol
@@ -15,6 +15,7 @@
 // limitations under the License.
 pragma solidity ^0.8.20;
 
+import {IZetoEncrypted} from "./lib/interfaces/izeto_encrypted.sol";
 import {Groth16Verifier_CheckHashesValue} from "./lib/verifier_check_hashes_value.sol";
 import {Groth16Verifier_CheckNullifierValue} from "./lib/verifier_check_nullifier_value.sol";
 import {Groth16Verifier_AnonEncNullifierKyc} from "./lib/verifier_anon_enc_nullifier_kyc.sol";
@@ -35,6 +36,7 @@ import "hardhat/console.sol";
 ///        - the encrypted value in the input is derived from the receiver's UTXO value and encrypted with a shared secret using the ECDH protocol between the sender and receiver (this guarantees data availability for the receiver)
 ///        - the nullifiers represent input commitments that are included in a Sparse Merkle Tree represented by the root hash
 contract Zeto_AnonEncNullifierKyc is
+    IZetoEncrypted,
     ZetoNullifier,
     ZetoFungibleWithdrawWithNullifiers,
     Registry,

--- a/solidity/contracts/zeto_anon_enc_nullifier_kyc.sol
+++ b/solidity/contracts/zeto_anon_enc_nullifier_kyc.sol
@@ -146,12 +146,13 @@ contract Zeto_AnonEncNullifierKyc is
     function deposit(
         uint256 amount,
         uint256 utxo,
-        Commonlib.Proof calldata proof
+        Commonlib.Proof calldata proof,
+        bytes calldata data
     ) public {
         _deposit(amount, utxo, proof);
         uint256[] memory utxos = new uint256[](1);
         utxos[0] = utxo;
-        _mint(utxos);
+        _mint(utxos, data);
     }
 
     function withdraw(
@@ -166,7 +167,7 @@ contract Zeto_AnonEncNullifierKyc is
         processInputsAndOutputs(nullifiers, [output, 0]);
     }
 
-    function mint(uint256[] memory utxos) public onlyOwner {
-        _mint(utxos);
+    function mint(uint256[] memory utxos, bytes calldata data) public onlyOwner {
+        _mint(utxos, data);
     }
 }

--- a/solidity/contracts/zeto_anon_enc_nullifier_kyc.sol
+++ b/solidity/contracts/zeto_anon_enc_nullifier_kyc.sol
@@ -24,7 +24,6 @@ import {ZetoFungibleWithdrawWithNullifiers} from "./lib/zeto_fungible_withdraw_n
 import {Registry} from "./lib/registry.sol";
 import {Commonlib} from "./lib/common.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
-import "hardhat/console.sol";
 
 /// @title A sample implementation of a Zeto based fungible token with anonymity, encryption and history masking
 /// @author Kaleido, Inc.

--- a/solidity/contracts/zeto_anon_enc_nullifier_kyc.sol
+++ b/solidity/contracts/zeto_anon_enc_nullifier_kyc.sol
@@ -83,7 +83,8 @@ contract Zeto_AnonEncNullifierKyc is
         uint256 root,
         uint256 encryptionNonce,
         uint256[4] memory encryptedValues,
-        Commonlib.Proof calldata proof
+        Commonlib.Proof calldata proof,
+        bytes calldata data
     ) public returns (bool) {
         require(
             validateTransactionProposal(nullifiers, outputs, root),
@@ -133,7 +134,8 @@ contract Zeto_AnonEncNullifierKyc is
             outputArray,
             encryptionNonce,
             encryptedValuesArray,
-            msg.sender
+            msg.sender,
+            data
         );
         return true;
     }

--- a/solidity/contracts/zeto_anon_enc_nullifier_non_repudiation.sol
+++ b/solidity/contracts/zeto_anon_enc_nullifier_non_repudiation.sol
@@ -182,12 +182,13 @@ contract Zeto_AnonEncNullifierNonRepudiation is
     function deposit(
         uint256 amount,
         uint256 utxo,
-        Commonlib.Proof calldata proof
+        Commonlib.Proof calldata proof,
+        bytes calldata data
     ) public {
         _deposit(amount, utxo, proof);
         uint256[] memory utxos = new uint256[](1);
         utxos[0] = utxo;
-        _mint(utxos);
+        _mint(utxos, data);
     }
 
     function withdraw(
@@ -202,7 +203,7 @@ contract Zeto_AnonEncNullifierNonRepudiation is
         processInputsAndOutputs(nullifiers, [output, 0]);
     }
 
-    function mint(uint256[] memory utxos) public onlyOwner {
-        _mint(utxos);
+    function mint(uint256[] memory utxos, bytes calldata data) public onlyOwner {
+        _mint(utxos, data);
     }
 }

--- a/solidity/contracts/zeto_anon_enc_nullifier_non_repudiation.sol
+++ b/solidity/contracts/zeto_anon_enc_nullifier_non_repudiation.sol
@@ -23,7 +23,6 @@ import {ZetoNullifier} from "./lib/zeto_nullifier.sol";
 import {ZetoFungibleWithdrawWithNullifiers} from "./lib/zeto_fungible_withdraw_nullifier.sol";
 import {Registry} from "./lib/registry.sol";
 import {Commonlib} from "./lib/common.sol";
-import "hardhat/console.sol";
 
 /// @title A sample implementation of a Zeto based fungible token with anonymity, encryption and history masking
 /// @author Kaleido, Inc.

--- a/solidity/contracts/zeto_anon_enc_nullifier_non_repudiation.sol
+++ b/solidity/contracts/zeto_anon_enc_nullifier_non_repudiation.sol
@@ -44,7 +44,8 @@ contract Zeto_AnonEncNullifierNonRepudiation is
         uint256 encryptionNonce,
         uint256[] encryptedValuesForReceiver,
         uint256[] encryptedValuesForAuthority,
-        address indexed submitter
+        address indexed submitter,
+        bytes data
     );
 
     Groth16Verifier_AnonEncNullifierNonRepudiation verifier;
@@ -100,7 +101,8 @@ contract Zeto_AnonEncNullifierNonRepudiation is
         uint256 encryptionNonce,
         uint256[4] memory encryptedValuesForReceiver,
         uint256[16] memory encryptedValuesForAuthority,
-        Commonlib.Proof calldata proof
+        Commonlib.Proof calldata proof,
+        bytes calldata data
     ) public returns (bool) {
         require(
             validateTransactionProposal(nullifiers, outputs, root),
@@ -174,7 +176,8 @@ contract Zeto_AnonEncNullifierNonRepudiation is
             encryptionNonce,
             encryptedValuesReceiverArray,
             encryptedValuesAuthorityArray,
-            msg.sender
+            msg.sender,
+            data
         );
         return true;
     }

--- a/solidity/contracts/zeto_anon_nullifier.sol
+++ b/solidity/contracts/zeto_anon_nullifier.sol
@@ -77,7 +77,8 @@ contract Zeto_AnonNullifier is
         uint256[2] memory nullifiers,
         uint256[2] memory outputs,
         uint256 root,
-        Commonlib.Proof calldata proof
+        Commonlib.Proof calldata proof,
+        bytes calldata data
     ) public returns (bool) {
         require(
             validateTransactionProposal(nullifiers, outputs, root),
@@ -108,7 +109,7 @@ contract Zeto_AnonNullifier is
             nullifierArray[i] = nullifiers[i];
             outputArray[i] = outputs[i];
         }
-        emit UTXOTransfer(nullifierArray, outputArray, msg.sender);
+        emit UTXOTransfer(nullifierArray, outputArray, msg.sender, data);
         return true;
     }
 

--- a/solidity/contracts/zeto_anon_nullifier.sol
+++ b/solidity/contracts/zeto_anon_nullifier.sol
@@ -115,12 +115,13 @@ contract Zeto_AnonNullifier is
     function deposit(
         uint256 amount,
         uint256 utxo,
-        Commonlib.Proof calldata proof
+        Commonlib.Proof calldata proof,
+        bytes calldata data
     ) public {
         _deposit(amount, utxo, proof);
         uint256[] memory utxos = new uint256[](1);
         utxos[0] = utxo;
-        _mint(utxos);
+        _mint(utxos, data);
     }
 
     function withdraw(
@@ -135,7 +136,7 @@ contract Zeto_AnonNullifier is
         processInputsAndOutputs(nullifiers, [output, 0]);
     }
 
-    function mint(uint256[] memory utxos) public onlyOwner {
-        _mint(utxos);
+    function mint(uint256[] memory utxos, bytes calldata data) public onlyOwner {
+        _mint(utxos, data);
     }
 }

--- a/solidity/contracts/zeto_anon_nullifier.sol
+++ b/solidity/contracts/zeto_anon_nullifier.sol
@@ -27,7 +27,6 @@ import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {SmtLib} from "@iden3/contracts/lib/SmtLib.sol";
 import {PoseidonUnit3L} from "@iden3/contracts/lib/Poseidon.sol";
-import "hardhat/console.sol";
 
 uint256 constant MAX_SMT_DEPTH = 64;
 

--- a/solidity/contracts/zeto_anon_nullifier.sol
+++ b/solidity/contracts/zeto_anon_nullifier.sol
@@ -15,6 +15,7 @@
 // limitations under the License.
 pragma solidity ^0.8.20;
 
+import {IZeto} from "./lib/interfaces/izeto.sol";
 import {Groth16Verifier_CheckHashesValue} from "./lib/verifier_check_hashes_value.sol";
 import {Groth16Verifier_CheckNullifierValue} from "./lib/verifier_check_nullifier_value.sol";
 import {Groth16Verifier_AnonNullifier} from "./lib/verifier_anon_nullifier.sol";
@@ -39,6 +40,7 @@ uint256 constant MAX_SMT_DEPTH = 64;
 ///        - the sender possesses the private BabyJubjub key, whose public key is part of the pre-image of the input commitment hashes, which match the corresponding nullifiers
 ///        - the nullifiers represent input commitments that are included in a Sparse Merkle Tree represented by the root hash
 contract Zeto_AnonNullifier is
+    IZeto,
     ZetoNullifier,
     ZetoFungibleWithdrawWithNullifiers,
     UUPSUpgradeable

--- a/solidity/contracts/zeto_anon_nullifier_kyc.sol
+++ b/solidity/contracts/zeto_anon_nullifier_kyc.sol
@@ -83,7 +83,8 @@ contract Zeto_AnonNullifierKyc is
         uint256[2] memory nullifiers,
         uint256[2] memory outputs,
         uint256 root,
-        Commonlib.Proof calldata proof
+        Commonlib.Proof calldata proof,
+        bytes calldata data
     ) public returns (bool) {
         require(
             validateTransactionProposal(nullifiers, outputs, root),
@@ -115,7 +116,7 @@ contract Zeto_AnonNullifierKyc is
             nullifierArray[i] = nullifiers[i];
             outputArray[i] = outputs[i];
         }
-        emit UTXOTransfer(nullifierArray, outputArray, msg.sender);
+        emit UTXOTransfer(nullifierArray, outputArray, msg.sender, data);
         return true;
     }
 

--- a/solidity/contracts/zeto_anon_nullifier_kyc.sol
+++ b/solidity/contracts/zeto_anon_nullifier_kyc.sol
@@ -15,6 +15,7 @@
 // limitations under the License.
 pragma solidity ^0.8.20;
 
+import {IZeto} from "./lib/interfaces/izeto.sol";
 import {Groth16Verifier_CheckHashesValue} from "./lib/verifier_check_hashes_value.sol";
 import {Groth16Verifier_CheckNullifierValue} from "./lib/verifier_check_nullifier_value.sol";
 import {Groth16Verifier_AnonNullifierKyc} from "./lib/verifier_anon_nullifier_kyc.sol";
@@ -39,6 +40,7 @@ uint256 constant MAX_SMT_DEPTH = 64;
 ///        - the sender possesses the private BabyJubjub key, whose public key is part of the pre-image of the input commitment hashes, which match the corresponding nullifiers
 ///        - the nullifiers represent input commitments that are included in a Sparse Merkle Tree represented by the root hash
 contract Zeto_AnonNullifierKyc is
+    IZeto,
     ZetoNullifier,
     ZetoFungibleWithdrawWithNullifiers,
     Registry,

--- a/solidity/contracts/zeto_anon_nullifier_kyc.sol
+++ b/solidity/contracts/zeto_anon_nullifier_kyc.sol
@@ -122,12 +122,13 @@ contract Zeto_AnonNullifierKyc is
     function deposit(
         uint256 amount,
         uint256 utxo,
-        Commonlib.Proof calldata proof
+        Commonlib.Proof calldata proof,
+        bytes calldata data
     ) public {
         _deposit(amount, utxo, proof);
         uint256[] memory utxos = new uint256[](1);
         utxos[0] = utxo;
-        _mint(utxos);
+        _mint(utxos, data);
     }
 
     function withdraw(
@@ -142,7 +143,7 @@ contract Zeto_AnonNullifierKyc is
         processInputsAndOutputs(nullifiers, [output, 0]);
     }
 
-    function mint(uint256[] memory utxos) public onlyOwner {
-        _mint(utxos);
+    function mint(uint256[] memory utxos, bytes calldata data) public onlyOwner {
+        _mint(utxos, data);
     }
 }

--- a/solidity/contracts/zeto_anon_nullifier_kyc.sol
+++ b/solidity/contracts/zeto_anon_nullifier_kyc.sol
@@ -27,7 +27,6 @@ import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {SmtLib} from "@iden3/contracts/lib/SmtLib.sol";
 import {PoseidonUnit3L} from "@iden3/contracts/lib/Poseidon.sol";
-import "hardhat/console.sol";
 
 uint256 constant MAX_SMT_DEPTH = 64;
 

--- a/solidity/contracts/zeto_nf_anon.sol
+++ b/solidity/contracts/zeto_nf_anon.sol
@@ -22,7 +22,6 @@ import {Registry} from "./lib/registry.sol";
 import {Commonlib} from "./lib/common.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
-import "hardhat/console.sol";
 
 /// @title A sample implementation of a Zeto based non-fungible token with anonymity and no encryption
 /// @author Kaleido, Inc.

--- a/solidity/contracts/zeto_nf_anon.sol
+++ b/solidity/contracts/zeto_nf_anon.sol
@@ -15,6 +15,7 @@
 // limitations under the License.
 pragma solidity ^0.8.20;
 
+import {IZeto} from "./lib/interfaces/izeto.sol";
 import {Groth16Verifier_NfAnon} from "./lib/verifier_nf_anon.sol";
 import {ZetoBase} from "./lib/zeto_base.sol";
 import {Registry} from "./lib/registry.sol";
@@ -29,7 +30,7 @@ import "hardhat/console.sol";
 ///        - The sender owns the private key whose public key is part of the pre-image of the input UTXOs commitments
 ///          (aka the sender is authorized to spend the input UTXOs)
 ///        - The input UTXOs and output UTXOs are valid in terms of obeying mass conservation rules
-contract Zeto_NfAnon is ZetoBase, UUPSUpgradeable {
+contract Zeto_NfAnon is IZeto, ZetoBase, UUPSUpgradeable {
     Groth16Verifier_NfAnon internal verifier;
 
     function initialize(

--- a/solidity/contracts/zeto_nf_anon.sol
+++ b/solidity/contracts/zeto_nf_anon.sol
@@ -55,7 +55,8 @@ contract Zeto_NfAnon is IZeto, ZetoBase, UUPSUpgradeable {
     function transfer(
         uint256 input,
         uint256 output,
-        Commonlib.Proof calldata proof
+        Commonlib.Proof calldata proof,
+        bytes calldata data
     ) public returns (bool) {
         require(
             validateTransactionProposal([input, 0], [output, 0], proof),
@@ -81,7 +82,7 @@ contract Zeto_NfAnon is IZeto, ZetoBase, UUPSUpgradeable {
         inputArray[0] = input;
         outputArray[0] = output;
 
-        emit UTXOTransfer(inputArray, outputArray, msg.sender);
+        emit UTXOTransfer(inputArray, outputArray, msg.sender, data);
         return true;
     }
 

--- a/solidity/contracts/zeto_nf_anon.sol
+++ b/solidity/contracts/zeto_nf_anon.sol
@@ -85,7 +85,7 @@ contract Zeto_NfAnon is IZeto, ZetoBase, UUPSUpgradeable {
         return true;
     }
 
-    function mint(uint256[] memory utxos) public {
-        _mint(utxos);
+    function mint(uint256[] memory utxos, bytes calldata data) public {
+        _mint(utxos, data);
     }
 }

--- a/solidity/contracts/zeto_nf_anon_nullifier.sol
+++ b/solidity/contracts/zeto_nf_anon_nullifier.sol
@@ -24,7 +24,6 @@ import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {SmtLib} from "@iden3/contracts/lib/SmtLib.sol";
 import {PoseidonUnit3L} from "@iden3/contracts/lib/Poseidon.sol";
-import "hardhat/console.sol";
 
 uint256 constant MAX_SMT_DEPTH = 64;
 

--- a/solidity/contracts/zeto_nf_anon_nullifier.sol
+++ b/solidity/contracts/zeto_nf_anon_nullifier.sol
@@ -93,7 +93,7 @@ contract Zeto_NfAnonNullifier is IZeto, ZetoNullifier, UUPSUpgradeable {
         return true;
     }
 
-    function mint(uint256[] memory utxos) public {
-        _mint(utxos);
+    function mint(uint256[] memory utxos, bytes calldata data) public {
+        _mint(utxos, data);
     }
 }

--- a/solidity/contracts/zeto_nf_anon_nullifier.sol
+++ b/solidity/contracts/zeto_nf_anon_nullifier.sol
@@ -15,6 +15,7 @@
 // limitations under the License.
 pragma solidity ^0.8.20;
 
+import {IZeto} from "./lib/interfaces/izeto.sol";
 import {Groth16Verifier_NfAnonNullifier} from "./lib/verifier_nf_anon_nullifier.sol";
 import {ZetoNullifier} from "./lib/zeto_nullifier.sol";
 import {Registry} from "./lib/registry.sol";
@@ -35,7 +36,7 @@ uint256 constant MAX_SMT_DEPTH = 64;
 ///        - the hashes in the input and output match the hash(value, salt, owner public key) formula
 ///        - the sender possesses the private BabyJubjub key, whose public key is part of the pre-image of the input commitment hashes, which match the corresponding nullifiers
 ///        - the nullifiers represent input commitments that are included in a Sparse Merkle Tree represented by the root hash
-contract Zeto_NfAnonNullifier is ZetoNullifier, UUPSUpgradeable {
+contract Zeto_NfAnonNullifier is IZeto, ZetoNullifier, UUPSUpgradeable {
     Groth16Verifier_NfAnonNullifier verifier;
 
     function initialize(

--- a/solidity/contracts/zeto_nf_anon_nullifier.sol
+++ b/solidity/contracts/zeto_nf_anon_nullifier.sol
@@ -63,7 +63,8 @@ contract Zeto_NfAnonNullifier is IZeto, ZetoNullifier, UUPSUpgradeable {
         uint256 nullifier,
         uint256 output,
         uint256 root,
-        Commonlib.Proof calldata proof
+        Commonlib.Proof calldata proof,
+        bytes calldata data
     ) public returns (bool) {
         require(
             validateTransactionProposal([nullifier, 0], [output, 0], root),
@@ -89,7 +90,7 @@ contract Zeto_NfAnonNullifier is IZeto, ZetoNullifier, UUPSUpgradeable {
         nullifierArray[0] = nullifier;
         outputArray[0] = output;
 
-        emit UTXOTransfer(nullifierArray, outputArray, msg.sender);
+        emit UTXOTransfer(nullifierArray, outputArray, msg.sender, data);
         return true;
     }
 

--- a/solidity/contracts/zkDvP.sol
+++ b/solidity/contracts/zkDvP.sol
@@ -18,7 +18,6 @@ pragma solidity ^0.8.20;
 import {Commonlib} from "./lib/common.sol";
 import {Zeto_Anon} from "./zeto_anon.sol";
 import {Zeto_NfAnon} from "./zeto_nf_anon.sol";
-import "hardhat/console.sol";
 
 /// @title A sample on-chain implementation of a DvP escrow contract using ZKP based C-UTXO tokens
 /// @author Kaleido, Inc.

--- a/solidity/contracts/zkDvP.sol
+++ b/solidity/contracts/zkDvP.sol
@@ -220,7 +220,8 @@ contract zkDvP {
                 paymentToken.transfer(
                     trade.paymentInputs,
                     trade.paymentOutputs,
-                    trade.paymentProof
+                    trade.paymentProof,
+                    ""
                 ),
                 "Payment branch of the trade failed"
             );
@@ -228,7 +229,8 @@ contract zkDvP {
                 assetToken.transfer(
                     trade.assetInput,
                     trade.assetOutput,
-                    trade.assetProof
+                    trade.assetProof,
+                    ""
                 ),
                 "Asset branch of the trade failed"
             );

--- a/solidity/test/lib/utils.ts
+++ b/solidity/test/lib/utils.ts
@@ -77,7 +77,9 @@ export function newAssetNullifier(utxo: UTXO, owner: User): UTXO {
 
 export async function doMint(zetoTokenContract: any, minter: Signer, outputs: UTXO[]): Promise<ContractTransactionReceipt> {
   const outputCommitments = outputs.map((output) => output.hash) as BigNumberish[];
-  const tx = await zetoTokenContract.connect(minter).mint(outputCommitments);
+  const tx = await zetoTokenContract
+    .connect(minter)
+    .mint(outputCommitments, "0x");
   const result = await tx.wait();
   console.log(`Method mint() complete. Gas used: ${result?.gasUsed}`);
   return result;

--- a/solidity/test/zeto_anon.ts
+++ b/solidity/test/zeto_anon.ts
@@ -221,7 +221,9 @@ describe("Zeto based fungible token with anonymity without encryption or nullifi
     encodedProof: any
   ) {
     const signerAddress = await signer.signer.getAddress();
-    const tx = await zeto.connect(signer.signer).transfer(inputCommitments, outputCommitments, encodedProof);
+    const tx = await zeto
+      .connect(signer.signer)
+      .transfer(inputCommitments, outputCommitments, encodedProof, "0x");
     const results = await tx.wait();
     console.log(`Method transfer() complete. Gas used: ${results?.gasUsed}`);
 

--- a/solidity/test/zeto_anon.ts
+++ b/solidity/test/zeto_anon.ts
@@ -72,7 +72,9 @@ describe("Zeto based fungible token with anonymity without encryption or nullifi
 
     utxo100 = newUTXO(100, Alice);
     const { outputCommitments, encodedProof } = await prepareDepositProof(Alice, utxo100);
-    const tx2 = await zeto.connect(Alice.signer).deposit(100, outputCommitments[0], encodedProof);
+    const tx2 = await zeto
+      .connect(Alice.signer)
+      .deposit(100, outputCommitments[0], encodedProof, "0x");
     await tx2.wait();
   });
 

--- a/solidity/test/zeto_anon_enc.ts
+++ b/solidity/test/zeto_anon_enc.ts
@@ -69,7 +69,9 @@ describe("Zeto based fungible token with anonymity and encryption", function () 
 
     utxo100 = newUTXO(100, Alice);
     const { outputCommitments, encodedProof } = await prepareDepositProof(Alice, utxo100);
-    const tx2 = await zeto.connect(Alice.signer).deposit(100, outputCommitments[0], encodedProof);
+    const tx2 = await zeto
+      .connect(Alice.signer)
+      .deposit(100, outputCommitments[0], encodedProof, "0x");
     await tx2.wait();
   });
 

--- a/solidity/test/zeto_anon_enc.ts
+++ b/solidity/test/zeto_anon_enc.ts
@@ -261,7 +261,16 @@ describe("Zeto based fungible token with anonymity and encryption", function () 
     encryptionNonce: BigNumberish,
     encodedProof: any
   ) {
-    const tx = await zeto.connect(signer.signer).transfer(inputCommitments, outputCommitments, encryptionNonce, encryptedValues, encodedProof);
+    const tx = await zeto
+      .connect(signer.signer)
+      .transfer(
+        inputCommitments,
+        outputCommitments,
+        encryptionNonce,
+        encryptedValues,
+        encodedProof,
+        "0x"
+      );
     const results: ContractTransactionReceipt | null = await tx.wait();
 
     for (const input of inputCommitments) {

--- a/solidity/test/zeto_anon_enc_nullifier.ts
+++ b/solidity/test/zeto_anon_enc_nullifier.ts
@@ -84,7 +84,9 @@ describe("Zeto based fungible token with anonymity using nullifiers and encrypti
 
     utxo100 = newUTXO(100, Alice);
     const { outputCommitments, encodedProof } = await prepareDepositProof(Alice, utxo100);
-    const tx2 = await zeto.connect(Alice.signer).deposit(100, outputCommitments[0], encodedProof);
+    const tx2 = await zeto
+      .connect(Alice.signer)
+      .deposit(100, outputCommitments[0], encodedProof, "0x");
     await tx2.wait();
 
     await smtAlice.add(utxo100.hash, utxo100.hash);

--- a/solidity/test/zeto_anon_enc_nullifier.ts
+++ b/solidity/test/zeto_anon_enc_nullifier.ts
@@ -417,7 +417,17 @@ describe("Zeto based fungible token with anonymity using nullifiers and encrypti
     encodedProof: any
   ) {
     const startTx = Date.now();
-    const tx = await zeto.connect(signer.signer).transfer(nullifiers, outputCommitments, root, encryptionNonce, encryptedValues, encodedProof);
+    const tx = await zeto
+      .connect(signer.signer)
+      .transfer(
+        nullifiers,
+        outputCommitments,
+        root,
+        encryptionNonce,
+        encryptedValues,
+        encodedProof,
+        "0x"
+      );
     const results: ContractTransactionReceipt | null = await tx.wait();
     console.log(`Time to execute transaction: ${Date.now() - startTx}ms. Gas used: ${results?.gasUsed}`);
     return results;

--- a/solidity/test/zeto_anon_enc_nullifier_kyc.ts
+++ b/solidity/test/zeto_anon_enc_nullifier_kyc.ts
@@ -953,7 +953,8 @@ describe('Zeto based fungible token with anonymity using nullifiers and encrypti
         root,
         encryptionNonce,
         encryptedValues,
-        encodedProof
+        encodedProof,
+        "0x"
       );
     const results: ContractTransactionReceipt | null = await tx.wait();
     console.log(

--- a/solidity/test/zeto_anon_enc_nullifier_kyc.ts
+++ b/solidity/test/zeto_anon_enc_nullifier_kyc.ts
@@ -134,7 +134,7 @@ describe('Zeto based fungible token with anonymity using nullifiers and encrypti
     );
     const tx2 = await zeto
       .connect(Alice.signer)
-      .deposit(100, outputCommitments[0], encodedProof);
+      .deposit(100, outputCommitments[0], encodedProof, "0x");
     await tx2.wait();
 
     await smtAlice.add(utxo100.hash, utxo100.hash);
@@ -394,7 +394,7 @@ describe('Zeto based fungible token with anonymity using nullifiers and encrypti
       );
       const tx2 = await zeto
         .connect(unregistered.signer)
-        .deposit(100, outputCommitments[0], encodedProof);
+        .deposit(100, outputCommitments[0], encodedProof, "0x");
       await tx2.wait();
 
       // Alice tracks the UTXO inside the SMT

--- a/solidity/test/zeto_anon_enc_nullifier_non_repudiation.ts
+++ b/solidity/test/zeto_anon_enc_nullifier_non_repudiation.ts
@@ -448,7 +448,18 @@ describe("Zeto based fungible token with anonymity using nullifiers and encrypti
     const startTx = Date.now();
     const encryptedValuesForReceiver = encryptedValues.slice(0, 4);
     const encryptedValuesForRegulator = encryptedValues.slice(4, 20);
-    const tx = await zeto.connect(signer.signer).transfer(nullifiers, outputCommitments, root, encryptionNonce, encryptedValuesForReceiver, encryptedValuesForRegulator, encodedProof);
+    const tx = await zeto
+      .connect(signer.signer)
+      .transfer(
+        nullifiers,
+        outputCommitments,
+        root,
+        encryptionNonce,
+        encryptedValuesForReceiver,
+        encryptedValuesForRegulator,
+        encodedProof,
+        "0x"
+      );
     const results: ContractTransactionReceipt | null = await tx.wait();
     console.log(`Time to execute transaction: ${Date.now() - startTx}ms. Gas used: ${results?.gasUsed}`);
     return results;

--- a/solidity/test/zeto_anon_enc_nullifier_non_repudiation.ts
+++ b/solidity/test/zeto_anon_enc_nullifier_non_repudiation.ts
@@ -89,7 +89,9 @@ describe("Zeto based fungible token with anonymity using nullifiers and encrypti
 
     utxo100 = newUTXO(100, Alice);
     const { outputCommitments, encodedProof } = await prepareDepositProof(Alice, utxo100);
-    const tx2 = await zeto.connect(Alice.signer).deposit(100, outputCommitments[0], encodedProof);
+    const tx2 = await zeto
+      .connect(Alice.signer)
+      .deposit(100, outputCommitments[0], encodedProof, "0x");
     await tx2.wait();
 
     await smtAlice.add(utxo100.hash, utxo100.hash);

--- a/solidity/test/zeto_anon_nullifier.ts
+++ b/solidity/test/zeto_anon_nullifier.ts
@@ -404,7 +404,9 @@ describe("Zeto based fungible token with anonymity using nullifiers without encr
     encodedProof: any
   ) {
     const startTx = Date.now();
-    const tx = await zeto.connect(signer.signer).transfer(nullifiers, outputCommitments, root, encodedProof);
+    const tx = await zeto
+      .connect(signer.signer)
+      .transfer(nullifiers, outputCommitments, root, encodedProof, "0x");
     const results: ContractTransactionReceipt | null = await tx.wait();
     console.log(`Time to execute transaction: ${Date.now() - startTx}ms. Gas used: ${results?.gasUsed}`);
     return results;

--- a/solidity/test/zeto_anon_nullifier.ts
+++ b/solidity/test/zeto_anon_nullifier.ts
@@ -84,7 +84,9 @@ describe("Zeto based fungible token with anonymity using nullifiers without encr
 
     utxo100 = newUTXO(100, Alice);
     const { outputCommitments, encodedProof } = await prepareDepositProof(Alice, utxo100);
-    const tx2 = await zeto.connect(Alice.signer).deposit(100, outputCommitments[0], encodedProof);
+    const tx2 = await zeto
+      .connect(Alice.signer)
+      .deposit(100, outputCommitments[0], encodedProof, "0x");
     await tx2.wait();
 
     await smtAlice.add(utxo100.hash, utxo100.hash);

--- a/solidity/test/zeto_anon_nullifier_kyc.ts
+++ b/solidity/test/zeto_anon_nullifier_kyc.ts
@@ -582,7 +582,9 @@ describe("Zeto based fungible token with anonymity, KYC, using nullifiers withou
     encodedProof: any
   ) {
     const startTx = Date.now();
-    const tx = await zeto.connect(signer.signer).transfer(nullifiers, outputCommitments, root, encodedProof);
+    const tx = await zeto
+      .connect(signer.signer)
+      .transfer(nullifiers, outputCommitments, root, encodedProof, "0x");
     const results: ContractTransactionReceipt | null = await tx.wait();
     console.log(`Time to execute transaction: ${Date.now() - startTx}ms. Gas used: ${results?.gasUsed}`);
     return results;

--- a/solidity/test/zeto_anon_nullifier_kyc.ts
+++ b/solidity/test/zeto_anon_nullifier_kyc.ts
@@ -105,8 +105,13 @@ describe("Zeto based fungible token with anonymity, KYC, using nullifiers withou
     await tx1.wait();
 
     utxo100 = newUTXO(100, Alice);
-    const { outputCommitments, encodedProof } = await prepareDepositProof(Alice, utxo100);
-    const tx2 = await zeto.connect(Alice.signer).deposit(100, outputCommitments[0], encodedProof);
+    const { outputCommitments, encodedProof } = await prepareDepositProof(
+      Alice,
+      utxo100
+    );
+    const tx2 = await zeto
+      .connect(Alice.signer)
+      .deposit(100, outputCommitments[0], encodedProof, "0x");
     await tx2.wait();
 
     await smtAlice.add(utxo100.hash, utxo100.hash);
@@ -281,8 +286,13 @@ describe("Zeto based fungible token with anonymity, KYC, using nullifiers withou
       await tx1.wait();
 
       unregisteredUtxo100 = newUTXO(100, unregistered);
-      const { outputCommitments, encodedProof } = await prepareDepositProof(unregistered, unregisteredUtxo100);
-      const tx2 = await zeto.connect(unregistered.signer).deposit(100, outputCommitments[0], encodedProof);
+      const { outputCommitments, encodedProof } = await prepareDepositProof(
+        unregistered,
+        unregisteredUtxo100
+      );
+      const tx2 = await zeto
+        .connect(unregistered.signer)
+        .deposit(100, outputCommitments[0], encodedProof, "0x");
       await tx2.wait();
 
       // Alice tracks the UTXO inside the SMT

--- a/solidity/test/zeto_nf_anon.ts
+++ b/solidity/test/zeto_nf_anon.ts
@@ -126,7 +126,9 @@ describe("Zeto based non-fungible token with anonymity without encryption or nul
     outputCommitment: BigNumberish,
     encodedProof: any
   ) {
-    const tx = await zeto.connect(signer.signer).transfer(inputCommitment, outputCommitment, encodedProof);
+    const tx = await zeto
+      .connect(signer.signer)
+      .transfer(inputCommitment, outputCommitment, encodedProof, "0x");
     const results = await tx.wait();
     console.log(`Method transfer() complete. Gas used: ${results?.gasUsed}`);
 

--- a/solidity/test/zeto_nf_anon_nullifier.ts
+++ b/solidity/test/zeto_nf_anon_nullifier.ts
@@ -264,7 +264,9 @@ describe("Zeto based non-fungible token with anonymity using nullifiers without 
     encodedProof: any
   ) {
     const startTx = Date.now();
-    const tx = await zeto.connect(signer.signer).transfer(nullifier, outputCommitment, root, encodedProof);
+    const tx = await zeto
+      .connect(signer.signer)
+      .transfer(nullifier, outputCommitment, root, encodedProof, "0x");
     const results: ContractTransactionReceipt | null = await tx.wait();
     console.log(`Time to execute transaction: ${Date.now() - startTx}ms. Gas used: ${results?.gasUsed}`);
     return results;


### PR DESCRIPTION
When performing token transfers, it's often beneficial to include additional data alongside the transfer. This can be to indicate the reason for the transfer, to tie it to an off-chain transaction, or to provide special instructions to derived token variants without altering the original contract interface.

One way to achieve this is by adding a `bytes data` parameter to the method signature, which is common in the Ethereum community and was codified in [ERC-5750](https://eips.ethereum.org/EIPS/eip-5750). Many existing standards, including ERC-721, ERC-1155, and ERC-1400 (specifically the [ERC-1594](https://github.com/ethereum/EIPs/issues/1594) component) all conform to this pattern.

I'd like to propose that Zeto also adopt this pattern and add `bytes data` to each of its mint/transfer methods and events. This does represent a change to the signatures.

Note: There are other ways to allow similar functionality _without_ changing the existing signatures (such as with method overloading, or emitting multiple events instead of only one) - but in my opinion the proposed route would be the cleanest and most consistent with other current token standards.