### PR TITLE
update the example to showcase concurrent "transfer"

### DIFF
--- a/solidity/package.json
+++ b/solidity/package.json
@@ -24,6 +24,7 @@
     "@iden3/contracts": "^2.0.5",
     "@openzeppelin/contracts": "^5.0.1",
     "@openzeppelin/contracts-upgradeable": "^5.0.2",
-    "@openzeppelin/hardhat-upgrades": "^3.2.1"
+    "@openzeppelin/hardhat-upgrades": "^3.2.1",
+    "async-lock": "^1.4.1"
   }
 }

--- a/solidity/test/gas_cost/zeto_anon_enc_nullifier_kyc_cost_analysis.ts
+++ b/solidity/test/gas_cost/zeto_anon_enc_nullifier_kyc_cost_analysis.ts
@@ -44,7 +44,7 @@ import {
 } from '../utils';
 import { deployZeto } from '../lib/deploy';
 
-const TOTAL_AMOUNT = parseInt(process.env.TOTAL_ROUNDS || '10');
+const TOTAL_AMOUNT = parseInt(process.env.TOTAL_ROUNDS || '1000');
 const TX_CONCURRENCY = parseInt(process.env.TX_CONCURRENCY || '30');
 
 export interface PreparedTransferData {
@@ -57,7 +57,7 @@ export interface PreparedTransferData {
   encodedProof: any;
 }
 
-describe.only('(Gas cost analysis) Zeto based fungible token with anonymity using nullifiers and encryption with KYC', function () {
+describe.skip('(Gas cost analysis) Zeto based fungible token with anonymity using nullifiers and encryption with KYC', function () {
   let deployer: Signer;
   let Alice: User;
   let Bob: User;

--- a/solidity/test/lib/utils.ts
+++ b/solidity/test/lib/utils.ts
@@ -89,7 +89,7 @@ export async function doMint(zetoTokenContract: any, minter: Signer, outputs: UT
 }
 
 export async function doDeposit(zetoTokenContract: any, depositUser: Signer, amount:any, commitment: any, proof: any, gasHistories?:number[]): Promise<ContractTransactionReceipt> {
-  const tx = await zetoTokenContract.connect(depositUser).deposit(amount, commitment, proof);
+  const tx = await zetoTokenContract.connect(depositUser).deposit(amount, commitment, proof, "0x");
   const result = await tx.wait();
   console.log(`Method deposit() complete. Gas used: ${result?.gasUsed}`);
   if (result?.gasUsed && Array.isArray(gasHistories)) {


### PR DESCRIPTION
This PR proves multiple Zeto transactions that are spending DIFFERENT utxos from the SAME owner can be submitted concurrently.

The proposed change separated proof generation & transaction submission to workaround an issue in the proof generation tooling: https://github.com/hyperledger-labs/zeto/issues/80