### PR TITLE
Split node reference vs. index to separate interfaces for API clarity

### DIFF
--- a/go-sdk/integration-test/db_test.go
+++ b/go-sdk/integration-test/db_test.go
@@ -103,7 +103,7 @@ func (s *SqliteTestSuite) TestSqliteStorage() {
 	dbRoot := core.SMTRoot{Name: s.smtName}
 	err = s.gormDB.Table(core.TreeRootsTable).First(&dbRoot).Error
 	assert.NoError(s.T(), err)
-	assert.Equal(s.T(), root.Hex(), dbRoot.RootIndex)
+	assert.Equal(s.T(), root.Hex(), dbRoot.RootRef)
 
 	dbNode := core.SMTNode{RefKey: n1.Ref().Hex()}
 	err = s.gormDB.Table(core.NodesTablePrefix + s.smtName).First(&dbNode).Error
@@ -155,7 +155,7 @@ func TestPostgresStorage(t *testing.T) {
 	dbRoot := core.SMTRoot{Name: "test_1"}
 	err = db.Table(core.TreeRootsTable).First(&dbRoot).Error
 	assert.NoError(t, err)
-	assert.Equal(t, root.Hex(), dbRoot.RootIndex)
+	assert.Equal(t, root.Hex(), dbRoot.RootRef)
 
 	dbNode := core.SMTNode{RefKey: n1.Ref().Hex()}
 	err = db.Table(core.NodesTablePrefix + "test_1").First(&dbNode).Error

--- a/go-sdk/internal/sparse-merkle-tree/node/node.go
+++ b/go-sdk/internal/sparse-merkle-tree/node/node.go
@@ -153,12 +153,12 @@ func (idx *nodeIndex) Equal(other core.NodeRef) bool {
 func (idx *nodeIndex) ToPath(levels int) []bool {
 	path := make([]bool, levels)
 	for l := 0; l < levels; l++ {
-		path[l] = idx.IsBitOn(uint(l))
+		path[l] = idx.IsBitOne(uint(l))
 	}
 	return path
 }
 
-func (idx *nodeIndex) IsBitOn(pos uint) bool {
+func (idx *nodeIndex) IsBitOne(pos uint) bool {
 	if pos >= 256 {
 		return false
 	}

--- a/go-sdk/internal/sparse-merkle-tree/node/node.go
+++ b/go-sdk/internal/sparse-merkle-tree/node/node.go
@@ -39,10 +39,10 @@ type nodeIndex [32]byte
 type node struct {
 	nodeType   core.NodeType
 	index      core.NodeIndex
-	refKey     core.NodeIndex
+	refKey     core.NodeRef
 	value      core.Indexable
-	leftChild  core.NodeIndex
-	rightChild core.NodeIndex
+	leftChild  core.NodeRef
+	rightChild core.NodeRef
 }
 
 // //////////////////////////////////////
@@ -70,7 +70,7 @@ func NewLeafNode(v core.Indexable) (core.Node, error) {
 	return n, err
 }
 
-func NewBranchNode(leftChild, rightChild core.NodeIndex) (core.Node, error) {
+func NewBranchNode(leftChild, rightChild core.NodeRef) (core.Node, error) {
 	n := &node{nodeType: core.NodeTypeBranch, leftChild: leftChild, rightChild: rightChild}
 	elements := []*big.Int{leftChild.BigInt(), rightChild.BigInt()}
 	hash, err := poseidon.Hash(elements)
@@ -89,7 +89,7 @@ func (n *node) Index() core.NodeIndex {
 	return n.index
 }
 
-func (n *node) Ref() core.NodeIndex {
+func (n *node) Ref() core.NodeRef {
 	return n.refKey
 }
 
@@ -97,11 +97,11 @@ func (n *node) Value() core.Indexable {
 	return n.value
 }
 
-func (n *node) LeftChild() core.NodeIndex {
+func (n *node) LeftChild() core.NodeRef {
 	return n.leftChild
 }
 
-func (n *node) RightChild() core.NodeIndex {
+func (n *node) RightChild() core.NodeRef {
 	return n.rightChild
 }
 
@@ -145,7 +145,7 @@ func (idx *nodeIndex) IsZero() bool {
 	return idx.BigInt().Sign() == 0
 }
 
-func (idx *nodeIndex) Equal(other core.NodeIndex) bool {
+func (idx *nodeIndex) Equal(other core.NodeRef) bool {
 	return idx.BigInt().Cmp(other.BigInt()) == 0
 }
 

--- a/go-sdk/internal/sparse-merkle-tree/smt/merkletree_test.go
+++ b/go-sdk/internal/sparse-merkle-tree/smt/merkletree_test.go
@@ -28,16 +28,16 @@ type mockStorage struct {
 	GetRootNodeIndex_customError bool
 }
 
-func (ms *mockStorage) GetRootNodeIndex() (core.NodeIndex, error) {
+func (ms *mockStorage) GetRootNodeRef() (core.NodeRef, error) {
 	if ms.GetRootNodeIndex_customError {
 		return nil, fmt.Errorf("nasty error in get root")
 	}
 	return nil, core.ErrNotFound
 }
-func (ms *mockStorage) UpsertRootNodeIndex(core.NodeIndex) error {
+func (ms *mockStorage) UpsertRootNodeRef(core.NodeRef) error {
 	return fmt.Errorf("nasty error in upsert root")
 }
-func (ms *mockStorage) GetNode(core.NodeIndex) (core.Node, error) {
+func (ms *mockStorage) GetNode(core.NodeRef) (core.Node, error) {
 	return nil, nil
 }
 func (ms *mockStorage) InsertNode(core.Node) error {

--- a/go-sdk/internal/sparse-merkle-tree/smt/proof.go
+++ b/go-sdk/internal/sparse-merkle-tree/smt/proof.go
@@ -89,7 +89,7 @@ func (p *proof) AllSiblings() []core.NodeRef {
 func (p *proof) getPath(index core.NodeIndex) []bool {
 	path := make([]bool, p.depth)
 	for n := 0; n < int(p.depth); n++ {
-		path[n] = index.IsBitOn(uint(n))
+		path[n] = index.IsBitOne(uint(n))
 	}
 	return path
 }

--- a/go-sdk/internal/sparse-merkle-tree/smt/proof.go
+++ b/go-sdk/internal/sparse-merkle-tree/smt/proof.go
@@ -28,7 +28,7 @@ import (
 // non-existence.
 type proof struct {
 	existence    bool
-	siblings     []core.NodeIndex
+	siblings     []core.NodeRef
 	depth        uint
 	existingNode core.Node
 	// nonEmptySiblings is a bitmap of non-empty Siblings found in Siblings. This helps
@@ -40,7 +40,7 @@ func (p *proof) IsExistenceProof() bool {
 	return p.existence
 }
 
-func (p *proof) Siblings() []core.NodeIndex {
+func (p *proof) Siblings() []core.NodeRef {
 	return p.siblings
 }
 
@@ -71,9 +71,9 @@ func (p *proof) IsNonEmptySibling(level uint) bool {
 	return isBitOnBigEndian(p.nonEmptySiblings, level)
 }
 
-func (p *proof) AllSiblings() []core.NodeIndex {
+func (p *proof) AllSiblings() []core.NodeRef {
 	sibIdx := 0
-	siblings := []core.NodeIndex{}
+	siblings := []core.NodeRef{}
 	for level := 0; level < int(p.depth); level++ {
 		if p.IsNonEmptySibling(uint(level)) {
 			siblings = append(siblings, p.siblings[sibIdx])
@@ -97,7 +97,7 @@ func (p *proof) getPath(index core.NodeIndex) []bool {
 // ToCircomVerifierProof enhances the generic merkle proof with additional
 // signals required by the circuit for Sparse Merkle Tree proof verification:
 // https://github.com/iden3/circomlib/blob/master/circuits/smt/smtverifier.circom
-func (p *proof) ToCircomVerifierProof(k, v *big.Int, rootKey core.NodeIndex, levels int) (*core.CircomVerifierProof, error) {
+func (p *proof) ToCircomVerifierProof(k, v *big.Int, rootKey core.NodeRef, levels int) (*core.CircomVerifierProof, error) {
 	var cp core.CircomVerifierProof
 	cp.Root = rootKey
 	cp.Siblings = p.AllSiblings()
@@ -131,7 +131,7 @@ func (p *proof) ToCircomVerifierProof(k, v *big.Int, rootKey core.NodeIndex, lev
 }
 
 // VerifyProof verifies the Merkle Proof for the entry and root.
-func VerifyProof(rootKey core.NodeIndex, p core.Proof, leafNode core.Node) bool {
+func VerifyProof(rootKey core.NodeRef, p core.Proof, leafNode core.Node) bool {
 	rootFromProof, err := calculateRootFromProof(p.(*proof), leafNode)
 	if err != nil {
 		return false
@@ -141,9 +141,9 @@ func VerifyProof(rootKey core.NodeIndex, p core.Proof, leafNode core.Node) bool 
 
 // CalculateRootFromProof calculates the root that would correspond to a tree whose
 // siblings are the ones in the proof with the leaf node
-func calculateRootFromProof(proof *proof, leafNode core.Node) (core.NodeIndex, error) {
+func calculateRootFromProof(proof *proof, leafNode core.Node) (core.NodeRef, error) {
 	sibIdx := len(proof.siblings) - 1
-	var midKey core.NodeIndex
+	var midKey core.NodeRef
 	if proof.existence {
 		midKey = leafNode.Ref()
 	} else {
@@ -157,7 +157,7 @@ func calculateRootFromProof(proof *proof, leafNode core.Node) (core.NodeIndex, e
 		}
 	}
 	path := proof.getPath(leafNode.Index())
-	var siblingKey core.NodeIndex
+	var siblingKey core.NodeRef
 	for level := int(proof.depth) - 1; level >= 0; level-- {
 		if proof.IsNonEmptySibling(uint(level)) {
 			siblingKey = proof.siblings[sibIdx]

--- a/go-sdk/internal/sparse-merkle-tree/smt/smt_test.go
+++ b/go-sdk/internal/sparse-merkle-tree/smt/smt_test.go
@@ -152,9 +152,12 @@ func (s *MerkleTreeTestSuite) TestAddNode() {
 
 	// test storage persistence
 	rawDB := mt.(*sparseMerkleTree).db
-	rootIdx, err := rawDB.GetRootNodeIndex()
+	rootIdx, err := rawDB.GetRootNodeRef()
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), "abacf46f5217552ee28fe50b8fd7ca6aa46daeb9acf9f60928654c3b1a472f23", rootIdx.Hex())
+	dbNode1, err := rawDB.GetNode(n1.Ref())
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), n1.Index().Hex(), dbNode1.Index().Hex())
 
 	// test storage persistence across tree creation
 	mt2, err := NewMerkleTree(s.db, 10)
@@ -242,7 +245,6 @@ func (s *MerkleTreeTestSuite) TestVerifyProof() {
 			assert.NoError(s.T(), err)
 			startProving <- node
 			done <- true
-			fmt.Printf("Added node %d\n", idx)
 		}(value, idx)
 	}
 

--- a/go-sdk/internal/sparse-merkle-tree/storage/sql.go
+++ b/go-sdk/internal/sparse-merkle-tree/storage/sql.go
@@ -41,7 +41,7 @@ func NewSqlStorage(p core.SqlDBProvider, smtName string) *sqlStorage {
 	}
 }
 
-func (s *sqlStorage) GetRootNodeIndex() (core.NodeIndex, error) {
+func (s *sqlStorage) GetRootNodeRef() (core.NodeRef, error) {
 	root := core.SMTRoot{
 		Name: s.smtName,
 	}
@@ -51,15 +51,15 @@ func (s *sqlStorage) GetRootNodeIndex() (core.NodeIndex, error) {
 	} else if err != nil {
 		return nil, err
 	}
-	idx, err := node.NewNodeIndexFromHex(root.RootIndex)
+	idx, err := node.NewNodeIndexFromHex(root.RootRef)
 	return idx, err
 }
 
-func (s *sqlStorage) UpsertRootNodeIndex(root core.NodeIndex) error {
-	return upsertRootNodeIndex(s.p.DB(), s.smtName, root)
+func (s *sqlStorage) UpsertRootNodeRef(root core.NodeRef) error {
+	return upsertRootNodeRef(s.p.DB(), s.smtName, root)
 }
 
-func (s *sqlStorage) GetNode(ref core.NodeIndex) (core.Node, error) {
+func (s *sqlStorage) GetNode(ref core.NodeRef) (core.Node, error) {
 	return getNode(s.p.DB(), s.nodesTableName, ref)
 }
 
@@ -81,11 +81,11 @@ type sqlTxStorage struct {
 	nodesTableName string
 }
 
-func (b *sqlTxStorage) UpsertRootNodeIndex(root core.NodeIndex) error {
-	return upsertRootNodeIndex(b.tx, b.smtName, root)
+func (b *sqlTxStorage) UpsertRootNodeRef(root core.NodeRef) error {
+	return upsertRootNodeRef(b.tx, b.smtName, root)
 }
 
-func (b *sqlTxStorage) GetNode(ref core.NodeIndex) (core.Node, error) {
+func (b *sqlTxStorage) GetNode(ref core.NodeRef) (core.Node, error) {
 	return getNode(b.tx, b.nodesTableName, ref)
 }
 
@@ -105,15 +105,15 @@ func (m *sqlStorage) Close() {
 	m.p.Close()
 }
 
-func upsertRootNodeIndex(batchOrDb *gorm.DB, name string, root core.NodeIndex) error {
+func upsertRootNodeRef(batchOrDb *gorm.DB, name string, root core.NodeRef) error {
 	err := batchOrDb.Table(core.TreeRootsTable).Save(&core.SMTRoot{
-		RootIndex: root.Hex(),
-		Name:      name,
+		RootRef: root.Hex(),
+		Name:    name,
 	}).Error
 	return err
 }
 
-func getNode(batchOrDb *gorm.DB, nodesTableName string, ref core.NodeIndex) (core.Node, error) {
+func getNode(batchOrDb *gorm.DB, nodesTableName string, ref core.NodeRef) (core.Node, error) {
 	// the node's reference key (not the index) is used as the key to
 	// store the node in the DB
 	n := core.SMTNode{

--- a/go-sdk/internal/sparse-merkle-tree/storage/sql_test.go
+++ b/go-sdk/internal/sparse-merkle-tree/storage/sql_test.go
@@ -68,16 +68,16 @@ func TestSqliteStorage(t *testing.T) {
 	assert.NoError(t, err)
 
 	idx, _ := utxo1.CalculateIndex()
-	err = s.UpsertRootNodeIndex(idx)
+	err = s.UpsertRootNodeRef(idx)
 	assert.NoError(t, err)
-	dbIdx, err := s.GetRootNodeIndex()
+	dbIdx, err := s.GetRootNodeRef()
 	assert.NoError(t, err)
 	assert.Equal(t, idx.Hex(), dbIdx.Hex())
 
 	dbRoot := core.SMTRoot{Name: "test_1"}
 	err = db.Table(core.TreeRootsTable).First(&dbRoot).Error
 	assert.NoError(t, err)
-	assert.Equal(t, idx.Hex(), dbRoot.RootIndex)
+	assert.Equal(t, idx.Hex(), dbRoot.RootRef)
 
 	err = s.InsertNode(n1)
 	assert.NoError(t, err)
@@ -114,13 +114,13 @@ func TestSqliteStorageFail_NoRootTable(t *testing.T) {
 	s := NewSqlStorage(provider, "test_1")
 	assert.NoError(t, err)
 
-	_, err = s.GetRootNodeIndex()
+	_, err = s.GetRootNodeRef()
 	assert.EqualError(t, err, "no such table: merkelTreeRoots")
 
 	err = db.Table(core.TreeRootsTable).AutoMigrate(&core.SMTRoot{})
 	assert.NoError(t, err)
 
-	_, err = s.GetRootNodeIndex()
+	_, err = s.GetRootNodeRef()
 	assert.EqualError(t, err, "key not found")
 }
 

--- a/go-sdk/pkg/sparse-merkle-tree/core/merkletree.go
+++ b/go-sdk/pkg/sparse-merkle-tree/core/merkletree.go
@@ -34,11 +34,14 @@ import "math/big"
 //	1 2 3 4 5 - - -     level 3
 type SparseMerkleTree interface {
 	// Root returns the root hash of the tree
-	Root() NodeIndex
+	Root() NodeRef
 	// AddLeaf adds a key-value pair to the tree
 	AddLeaf(leaf Node) error
 	// GetNode returns the node at the given reference hash
-	GetNode(node NodeIndex) (Node, error)
+	// nodeRef: the reference hash of the node (node.Ref()). Note, this is NOT the index of the node
+	GetNode(nodeRef NodeRef) (Node, error)
 	// GetnerateProof generates a proof of existence (or non-existence) of a leaf node
-	GenerateProofs(nodeIndexes []*big.Int, root NodeIndex) ([]Proof, []*big.Int, error)
+	// nodeIndexes: the index of the leaf nodes to generate proofs for
+	// rootRef: the reference hash of the root node
+	GenerateProofs(nodeIndexes []*big.Int, rootRef NodeRef) ([]Proof, []*big.Int, error)
 }

--- a/go-sdk/pkg/sparse-merkle-tree/core/node.go
+++ b/go-sdk/pkg/sparse-merkle-tree/core/node.go
@@ -49,8 +49,8 @@ type NodeRef interface {
 // NodeIndex defines the functions of leaf nodes in the SMT, which provide access to their node paths in addition to the NodeRef functions.
 type NodeIndex interface {
 	NodeRef
-	// IsBitOn returns true if the index bit at the given position is 1
-	IsBitOn(uint) bool
+	// IsBitOne returns true if the index bit at the given position is 1
+	IsBitOne(uint) bool
 	// ToPath returns the binary path from the root to the leaf
 	ToPath(int) []bool
 }

--- a/go-sdk/pkg/sparse-merkle-tree/core/node.go
+++ b/go-sdk/pkg/sparse-merkle-tree/core/node.go
@@ -42,7 +42,7 @@ type NodeRef interface {
 	Hex() string
 	// IsZero returns true if the reference hash is zero
 	IsZero() bool
-	// Equal returns true if the index is equal to another index
+	// Equal returns true if two reference hashes equal to each other
 	Equal(NodeRef) bool
 }
 

--- a/go-sdk/pkg/sparse-merkle-tree/core/node.go
+++ b/go-sdk/pkg/sparse-merkle-tree/core/node.go
@@ -34,8 +34,7 @@ const (
 	NodeTypeLeaf
 )
 
-// NodeIndex is the index of a node in the Sparse Merkle Tree
-type NodeIndex interface {
+type NodeRef interface {
 	// BigInt returns the big integer representation of the index
 	BigInt() *big.Int
 	// Hex returns the hex string representation of the index in big-endian format
@@ -43,7 +42,12 @@ type NodeIndex interface {
 	// IsZero returns true if the index is zero
 	IsZero() bool
 	// Equal returns true if the index is equal to another index
-	Equal(NodeIndex) bool
+	Equal(NodeRef) bool
+}
+
+// NodeIndex is the index of a node in the Sparse Merkle Tree
+type NodeIndex interface {
+	NodeRef
 	// IsBitOn returns true if the index bit at the given position is 1
 	IsBitOn(uint) bool
 	// ToPath returns the binary path from the root to the leaf
@@ -68,15 +72,15 @@ type Node interface {
 	// calculated by combining the index and value of the node, as
 	// the reference to the node from its parent in the tree, as well as the
 	// key to the storage record for the node
-	Ref() NodeIndex
+	Ref() NodeRef
 	// returns the value object. only leaf nodes have a value object. If the
 	// client is the owner of a UTXO, the value object includes the secret values.
 	// otherwise the value object is simply the index of the node.
 	Value() Indexable
 	// returns the index of the left child. Only branch nodes have a left child.
-	LeftChild() NodeIndex
+	LeftChild() NodeRef
 	// returns the index of the right child. Only branch nodes have a right child.
-	RightChild() NodeIndex
+	RightChild() NodeRef
 }
 
 func (t NodeType) ToByte() byte {

--- a/go-sdk/pkg/sparse-merkle-tree/core/node.go
+++ b/go-sdk/pkg/sparse-merkle-tree/core/node.go
@@ -40,7 +40,7 @@ type NodeRef interface {
 	BigInt() *big.Int
 	// Hex returns the hex string representation of the reference hash in big-endian format
 	Hex() string
-	// IsZero returns true if the index is zero
+	// IsZero returns true if the reference hash is zero
 	IsZero() bool
 	// Equal returns true if the index is equal to another index
 	Equal(NodeRef) bool

--- a/go-sdk/pkg/sparse-merkle-tree/core/node.go
+++ b/go-sdk/pkg/sparse-merkle-tree/core/node.go
@@ -36,7 +36,7 @@ const (
 
 // NodeRef defines functions associated with the reference hash of SMT nodes, this interface applies to all types of nodes (reference hash calculated differently depending on node type)
 type NodeRef interface {
-	// BigInt returns the big integer representation of the index
+	// BigInt returns the big integer representation of the reference hash
 	BigInt() *big.Int
 	// Hex returns the hex string representation of the index in big-endian format
 	Hex() string

--- a/go-sdk/pkg/sparse-merkle-tree/core/node.go
+++ b/go-sdk/pkg/sparse-merkle-tree/core/node.go
@@ -46,7 +46,7 @@ type NodeRef interface {
 	Equal(NodeRef) bool
 }
 
-// NodeIndex is the index of a node in the Sparse Merkle Tree
+// NodeIndex defines the functions of leaf nodes in the SMT, which provide access to their node paths in addition to the NodeRef functions.
 type NodeIndex interface {
 	NodeRef
 	// IsBitOn returns true if the index bit at the given position is 1

--- a/go-sdk/pkg/sparse-merkle-tree/core/node.go
+++ b/go-sdk/pkg/sparse-merkle-tree/core/node.go
@@ -38,7 +38,7 @@ const (
 type NodeRef interface {
 	// BigInt returns the big integer representation of the reference hash
 	BigInt() *big.Int
-	// Hex returns the hex string representation of the index in big-endian format
+	// Hex returns the hex string representation of the reference hash in big-endian format
 	Hex() string
 	// IsZero returns true if the index is zero
 	IsZero() bool

--- a/go-sdk/pkg/sparse-merkle-tree/core/node.go
+++ b/go-sdk/pkg/sparse-merkle-tree/core/node.go
@@ -34,6 +34,7 @@ const (
 	NodeTypeLeaf
 )
 
+// NodeRef defines functions associated with the reference hash of SMT nodes, this interface applies to all types of nodes (reference hash calculated differently depending on node type)
 type NodeRef interface {
 	// BigInt returns the big integer representation of the index
 	BigInt() *big.Int

--- a/go-sdk/pkg/sparse-merkle-tree/core/proof.go
+++ b/go-sdk/pkg/sparse-merkle-tree/core/proof.go
@@ -24,7 +24,7 @@ type Proof interface {
 	// existence indicates wether this is a proof of existence or non-existence.
 	IsExistenceProof() bool
 	// Siblings is a list of non-empty sibling keys.
-	Siblings() []NodeIndex
+	Siblings() []NodeRef
 	// depth indicates how deep in the tree the proof goes.
 	Depth() uint
 	// ExistingNode is only used in a non-existence proof. It's the node
@@ -33,19 +33,19 @@ type Proof interface {
 	// demonstrating non-inclusion of the target node.
 	ExistingNode() Node
 	// ToCircomVerifierProof converts the proof to a CircomVerifierProof
-	ToCircomVerifierProof(k, v *big.Int, rootKey NodeIndex, levels int) (*CircomVerifierProof, error)
+	ToCircomVerifierProof(k, v *big.Int, rootKey NodeRef, levels int) (*CircomVerifierProof, error)
 }
 
 // CircomVerifierProof defines the proof with signals compatible with circom's SMT proof
 // verification:
 // https://github.com/iden3/circomlib/blob/master/circuits/smt/smtverifier.circom
 type CircomVerifierProof struct {
-	Root     NodeIndex   `json:"root"`
-	Siblings []NodeIndex `json:"siblings"`
-	OldKey   NodeIndex   `json:"oldKey"`
-	OldValue NodeIndex   `json:"oldValue"`
-	IsOld0   bool        `json:"isOld0"`
-	Key      NodeIndex   `json:"key"`
-	Value    NodeIndex   `json:"value"`
-	Fnc      int         `json:"fnc"` // 0: inclusion, 1: non inclusion
+	Root     NodeRef   `json:"root"`
+	Siblings []NodeRef `json:"siblings"`
+	OldKey   NodeIndex `json:"oldKey"`
+	OldValue NodeIndex `json:"oldValue"`
+	IsOld0   bool      `json:"isOld0"`
+	Key      NodeIndex `json:"key"`
+	Value    NodeIndex `json:"value"`
+	Fnc      int       `json:"fnc"` // 0: inclusion, 1: non inclusion
 }

--- a/go-sdk/pkg/sparse-merkle-tree/core/storage.go
+++ b/go-sdk/pkg/sparse-merkle-tree/core/storage.go
@@ -19,14 +19,14 @@ package core
 import "gorm.io/gorm"
 
 type Storage interface {
-	// GetRootNodeIndex returns the root node index.
+	// GetRootNodeRef returns the root node index.
 	// Must return an ErrNotFound error if it does not exist.
-	GetRootNodeIndex() (NodeIndex, error)
+	GetRootNodeRef() (NodeRef, error)
 	// UpsertRootNodeIndex updates the root node index.
-	UpsertRootNodeIndex(NodeIndex) error
-	// GetNode returns the node with the given index
+	UpsertRootNodeRef(NodeRef) error
+	// GetNode returns the node with the given reference hash
 	// Must return an ErrNotFound error if it does not exist.
-	GetNode(NodeIndex) (Node, error)
+	GetNode(NodeRef) (Node, error)
 	// InsertNode inserts a node into the storage. Where the private values of a node are stored
 	// is implementation-specific
 	InsertNode(Node) error
@@ -38,8 +38,8 @@ type Storage interface {
 }
 
 type Transaction interface {
-	UpsertRootNodeIndex(NodeIndex) error
-	GetNode(NodeIndex) (Node, error)
+	UpsertRootNodeRef(NodeRef) error
+	GetNode(NodeRef) (Node, error)
 	InsertNode(Node) error
 	Commit() error
 	Rollback() error
@@ -66,9 +66,9 @@ type SqlDBProvider interface {
 type SMTRoot struct {
 	// the name of the merkle tree
 	Name string `gorm:"primaryKey"`
-	// this must be the hex bytes of the root index
+	// this must be the hex bytes of the root reference hash
 	// following the big-endian encoding
-	RootIndex string `gorm:"size:64"`
+	RootRef string `gorm:"size:64"`
 }
 
 // SMTNode is the structure of a node in the merkle tree.

--- a/go-sdk/pkg/sparse-merkle-tree/node/node.go
+++ b/go-sdk/pkg/sparse-merkle-tree/node/node.go
@@ -33,7 +33,7 @@ func NewLeafNode(v core.Indexable) (core.Node, error) {
 	return node.NewLeafNode(v)
 }
 
-func NewBranchNode(leftChild, rightChild core.NodeIndex) (core.Node, error) {
+func NewBranchNode(leftChild, rightChild core.NodeRef) (core.Node, error) {
 	return node.NewBranchNode(leftChild, rightChild)
 }
 


### PR DESCRIPTION
The node reference is a hash of the index + value + 1, which is used to refer to a node in the sparse merkle tree. The node index is used to position the node in the tree, which determines the path used to traverse from the root to the leaf node (branch nodes do not have an index).

Currently the usage of a reference and an index are mixed, making it confusing in the code, as well as the API surface. This PR splits them into separate interfaces, with the index being a superset of the reference interface.