### PR TITLE
Do not force logrus LogLevel on first log line

### DIFF
--- a/go-sdk/internal/log/log.go
+++ b/go-sdk/internal/log/log.go
@@ -33,6 +33,8 @@ var (
 	initAtLeastOnce atomic.Bool
 )
 
+// Optional to call if you wish to use Zeto's configuration for logging.
+// Otherwise standard logrus logging will be used as configured by your own environment
 func InitConfig() {
 	initAtLeastOnce.Store(true) // must store before SetLevel
 
@@ -51,22 +53,12 @@ func InitConfig() {
 	logrus.SetFormatter(formatter)
 }
 
-func ensureInit() {
-	// Called at a couple of strategic points to check we get log initialize in things like unit tests
-	// However NOT guaranteed to be called because we can't afford to do atomic load on every log line
-	if !initAtLeastOnce.Load() {
-		InitConfig()
-	}
-}
-
 func logger() *logrus.Entry {
-	ensureInit()
 	return rootLogger
 }
 
 // WithLogField adds the specified field to the logger in the context
 func WithLogField(key, value string) *logrus.Entry {
-	ensureInit()
 	if len(value) > 61 {
 		value = value[0:61] + "..."
 	}


### PR DESCRIPTION
When embedding Zeto, such as in Paladin, the fact that `logrus.SetLevel` is called on first log line, is challenging as it resets the logging framework of the parent containing Go code.

This PR instead suggests that callers need to cal `log.InitConfig` directly if they wish to use Zeto as the primary logging configuration framework for their codebase.