### PR TITLE
Update ".ts file extension" in README.md

### DIFF
--- a/solidity/README.md
+++ b/solidity/README.md
@@ -14,14 +14,14 @@ Zeto token contracts are all upgradeable contracts. They can be deployed with on
 
 ```console
 export ZETO_NAME=Zeto_AnonEncNullifier
-npx hardhat run scripts/deploy_upgradeable.js
+npx hardhat run scripts/deploy_upgradeable.ts
 ```
 
 - [deploy_cloneable](/solidity/scripts/deploy_cloneable.ts): Deploys the target contract, designated by the `ZETO_NAME` environment variable, as a [cloneable contract](https://blog.openzeppelin.com/workshop-recap-cheap-contract-deployment-through-clones).
 
 ```console
 export ZETO_NAME=Zeto_AnonEncNullifier
-npx hardhat run scripts/deploy_cloneable.js
+npx hardhat run scripts/deploy_cloneable.ts
 ```
 
 # Run The Hardhat Tests


### PR DESCRIPTION
The README provides 2 commands to deploy contracts:

1. npx hardhat run scripts/deploy_upgradeable.js
2. npx hardhat run scripts/deploy_cloneable.js

But the mentioned files do not exist:
- scripts/deploy_upgradeable.js
- scripts/deploy_cloneable.js

And the correct files are:
- scripts/deploy_upgradeable.ts
- scripts/deploy_cloneable.ts

So correct command to deploy contracts are:
`npx hardhat run scripts/deploy_upgradeable.js`
`npx hardhat run scripts/deploy_cloneable.js`
