### PR TITLE
fix: Add release trigger to docs actions

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,6 +1,8 @@
 name: Docs Site
 
 on:
+  release:
+    types: [released]
   push:
     branches:
       - main


### PR DESCRIPTION
The docs site wasn't being update on a release, and the action relies on the release trigger to update the latest version of the website.

Will need a manual fix to update the latest, will I will raise as a separate PR