### PR TITLE
Use a Personal Access Token to create a release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -115,5 +115,4 @@ jobs:
           allowUpdates: 'true'
           artifacts: zeto-wasm-and-proving-keys/*.tar.gz
           tag: ${{ env.ZETO_VER }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PAT }}


### PR DESCRIPTION
In an attempt to fix triggering docs build on release creation by pushing tags. Due to limitations for github workflow triggering, we need to use alternative secrets than GITHUB_TOKEN per this doc: https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow#triggering-a-workflow-from-a-workflow