### PR TITLE
release-solidity-package should be callable by workflow dispatch only

### DIFF
--- a/.github/workflows/release-solidity-package.yaml
+++ b/.github/workflows/release-solidity-package.yaml
@@ -4,7 +4,7 @@ permissions:
   contents: read
   id-token: write
 on:
-  workflow_call:
+  workflow_dispatch:
     inputs:
       ref:
         description: "Commit ref for checkout"


### PR DESCRIPTION
I got these the wrong way round on my last PR. This workflow is going to be the trusted publisher so must only be dispatched directly and not called by another workflow.