### PR TITLE
Update actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,39 @@
+# Dependabot configuration.
+# Updates are grouped per ecosystem so each ecosystem opens a single PR.
+version: 2
+updates:
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  # Go modules
+  - package-ecosystem: "gomod"
+    directories:
+      - "/"
+      - "/go-sdk/src"
+      - "/go-sdk/integration-test"
+    schedule:
+      interval: "weekly"
+    groups:
+      gomod:
+        patterns:
+          - "*"
+
+  # npm (Solidity + circuits/JS)
+  - package-ecosystem: "npm"
+    directories:
+      - "/solidity"
+      - "/zkp/js"
+      - "/zkp/circuits"
+    schedule:
+      interval: "weekly"
+    groups:
+      npm:
+        patterns:
+          - "*"

--- a/.github/workflows/circuit-unit-tests.yaml
+++ b/.github/workflows/circuit-unit-tests.yaml
@@ -20,21 +20,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20
 
       - name: Install circom
-        uses: supplypike/setup-bin@v4
+        uses: supplypike/setup-bin@8365380a806a88e7a0f0d07059b175ca2f5418d7 # v5.0.1
         with:
           uri: https://github.com/iden3/circom/releases/download/v2.2.2/circom-linux-amd64
           name: circom
           version: 2.2.2
 
       - name: Checkout circuits
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install circuit dependencies
         working-directory: zkp/circuits

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -22,9 +22,10 @@ jobs:
       contents: write
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Docs Deploy
         run: |
@@ -45,14 +46,18 @@ jobs:
       - name: Update doc site for release
         if: github.event.action == 'released' && github.ref_name != env.LATEST_TAG
         working-directory: doc-site
-        run: mike deploy ${{ github.event.release.tag_name }} --push
+        run: mike deploy ${GITHUB_EVENT_RELEASE_TAG_NAME} --push
+        env:
+          GITHUB_EVENT_RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
 
       - name: Update doc site for latest release
         if: github.event.action == 'released' && github.ref_name == env.LATEST_TAG
         working-directory: doc-site
         run: |
-          mike deploy ${{ github.event.release.tag_name }} latest -u --push
+          mike deploy ${GITHUB_EVENT_RELEASE_TAG_NAME} latest -u --push
           mike set-default --push latest
+        env:
+          GITHUB_EVENT_RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
 
       - name: Update doc site for `main` branch
         if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/e2e-deps.yaml
+++ b/.github/workflows/e2e-deps.yaml
@@ -13,20 +13,22 @@ jobs:
       artifacts-name: ${{ steps.artifacts-name.outputs.artifacts-name }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Free up disk space on runner
         uses: ./.github/actions/free-up-disk-space
 
       - name: Install circom
-        uses: supplypike/setup-bin@v4
+        uses: supplypike/setup-bin@8365380a806a88e7a0f0d07059b175ca2f5418d7 # v5.0.1
         with:
           uri: https://github.com/iden3/circom/releases/download/v2.2.2/circom-linux-amd64
           name: circom
           version: 2.2.2
 
       - name: Setup node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20
 
@@ -35,10 +37,11 @@ jobs:
           npm install -g snarkjs
 
       - name: Checkout Zeto
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           path: zeto
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup temp dir for the artifacts
         run: |
@@ -68,7 +71,7 @@ jobs:
 
       - name: Upload zeto artifacts
         id: upload-artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ steps.artifacts-name.outputs.artifacts-name }}
           path: ${{ runner.temp }}/zeto-artifacts

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -41,44 +41,48 @@ jobs:
           - 5432:5432
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Free up disk space on runner
         uses: ./.github/actions/free-up-disk-space
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: 1.25.9
 
       - name: Setup node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
 
       - name: Checkout Zeto
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           path: zeto
           fetch-depth: 0
+          persist-credentials: false
 
       # Using the `keccak256` branch of the `kaleido-io/contracts` repository
       # which is a fork of the `iden3/contracts` repository with the `keccak256` hash function
       # used for the Sparse Merkle Tree, with breaking changes since Poseidon is no longer the default.
       - name: Checkout iden3/contracts
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: kaleido-io/contracts
           ref: keccak256
           path: contracts
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup temp dir for the artifacts
         run: |
           mkdir -p ${{ runner.temp }}/zeto-artifacts
 
       - name: Download zeto artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ needs.setup-prerequisites.outputs.artifacts-name }}
           path: ${{ runner.temp }}/zeto-artifacts

--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -21,12 +21,13 @@ jobs:
       TEST_ARGS: -v
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: 1.25.9
 
@@ -34,7 +35,7 @@ jobs:
         working-directory: go-sdk/src
         run: make
 
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           codecov_yml_path: ./go-sdk/src/coverage.txt
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/release-solidity-package.yaml
+++ b/.github/workflows/release-solidity-package.yaml
@@ -23,24 +23,28 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
+          persist-credentials: false
 
       - name: Print workflow inputs
         shell: bash
         run: |
           echo "=== Workflow Inputs ==="
           echo "ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}"
-          echo "package_version: ${{ inputs.package_version }}"
-          echo "package_tag: ${{ inputs.package_tag }}"
+          echo "package_version: ${INPUTS_PACKAGE_VERSION}"
+          echo "package_tag: ${INPUTS_PACKAGE_TAG}"
           echo "======================"
+        env:
+          INPUTS_PACKAGE_VERSION: ${{ inputs.package_version }}
+          INPUTS_PACKAGE_TAG: ${{ inputs.package_tag }}
 
       # Avoid Node 22.22.2: bundled npm breaks global upgrades with MODULE_NOT_FOUND
       # 'promise-retry' (nodejs/node#62430, npm/cli#9151). Minimum npm 11.11.0 satisfies
       # trusted publishing and replaces promise-retry with @gar/promise-retry.
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
@@ -59,7 +63,9 @@ jobs:
         id: prep_version
         shell: bash
         run: |
-          echo "clean_version=$(echo "${{ inputs.package_version }}" | sed 's/^v//')" >> $GITHUB_OUTPUT
+          echo "clean_version=$(echo "${INPUTS_PACKAGE_VERSION}" | sed 's/^v//')" >> $GITHUB_OUTPUT
+        env:
+          INPUTS_PACKAGE_VERSION: ${{ inputs.package_version }}
 
       - name: Update package.json name and version
         working-directory: solidity
@@ -79,17 +85,19 @@ jobs:
           SCOPED_NAME="@lfdecentralizedtrust/${BASE_NAME}"
 
           # Update name (with scope) and version
-          jq --arg name "$SCOPED_NAME" --arg version "${{ steps.prep_version.outputs.clean_version }}" \
+          jq --arg name "$SCOPED_NAME" --arg version "${STEPS_PREP_VERSION_OUTPUTS_CLEAN_VERSION}" \
             '.name = $name | .version = $version' package.json > temp.json && mv temp.json package.json
 
           echo "Updated package.json:"
           cat package.json
+        env:
+          STEPS_PREP_VERSION_OUTPUTS_CLEAN_VERSION: ${{ steps.prep_version.outputs.clean_version }}
 
       - name: Parse NPM tags
         id: parse_tags
         shell: bash
         run: |
-          TAG_LIST="${{ inputs.package_tag }}"
+          TAG_LIST="${INPUTS_PACKAGE_TAG}"
 
           # Group all writes to the GITHUB_OUTPUT file
           {
@@ -103,13 +111,17 @@ jobs:
             echo "$ADDITIONAL_TAGS" | tr ';' '\n'
             echo "EOF"
           } >> $GITHUB_OUTPUT
+        env:
+          INPUTS_PACKAGE_TAG: ${{ inputs.package_tag }}
 
       - name: Publish to npm with primary tag
         working-directory: solidity
         shell: bash
         run: |
           set -e
-          npm publish --provenance --access public --tag ${{ steps.parse_tags.outputs.primary_tag }}
+          npm publish --provenance --access public --tag ${STEPS_PARSE_TAGS_OUTPUTS_PRIMARY_TAG}
+        env:
+          STEPS_PARSE_TAGS_OUTPUTS_PRIMARY_TAG: ${{ steps.parse_tags.outputs.primary_tag }}
 
       - name: Add additional dist-tags
         if: steps.parse_tags.outputs.additional_tags != ''
@@ -121,7 +133,7 @@ jobs:
           # Get the package name from package.json
           PACKAGE_NAME=$(jq -r '.name' package.json)
           # The version for `dist-tag add` must not have the 'v' prefix
-          PACKAGE_SPEC="${PACKAGE_NAME}@${{ steps.prep_version.outputs.clean_version }}"
+          PACKAGE_SPEC="${PACKAGE_NAME}@${STEPS_PREP_VERSION_OUTPUTS_CLEAN_VERSION}"
 
           echo "Adding tags for $PACKAGE_SPEC..."
 
@@ -131,4 +143,7 @@ jobs:
               echo "Adding tag: $tag"
               npm dist-tag add "$PACKAGE_SPEC" "$tag"
             fi
-          done <<< "${{ steps.parse_tags.outputs.additional_tags }}"
+          done <<< "${STEPS_PARSE_TAGS_OUTPUTS_ADDITIONAL_TAGS}"
+        env:
+          STEPS_PREP_VERSION_OUTPUTS_CLEAN_VERSION: ${{ steps.prep_version.outputs.clean_version }}
+          STEPS_PARSE_TAGS_OUTPUTS_ADDITIONAL_TAGS: ${{ steps.parse_tags.outputs.additional_tags }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,17 +17,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Install circom
-        uses: supplypike/setup-bin@v4
+        uses: supplypike/setup-bin@8365380a806a88e7a0f0d07059b175ca2f5418d7 # v5.0.1
         with:
           uri: https://github.com/iden3/circom/releases/download/v2.2.2/circom-linux-amd64
           name: circom
           version: 2.2.2
 
       - name: Setup node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20
 
@@ -36,10 +38,11 @@ jobs:
           npm install -g snarkjs
 
       - name: Checkout circuits
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           path: zeto
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Free up disk space on runner
         uses: ./.github/actions/free-up-disk-space
@@ -49,7 +52,7 @@ jobs:
           mkdir -p ${{ runner.temp }}/zeto-artifacts
 
       - name: Download zeto artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ needs.setup-prerequisites.outputs.artifacts-name }}
           path: ${{ runner.temp }}/zeto-artifacts
@@ -58,12 +61,13 @@ jobs:
       # which is a fork of the `iden3/contracts` repository with the `keccak256` hash function
       # used for the Sparse Merkle Tree, with breaking changes since Poseidon is no longer the default.
       - name: Checkout iden3/contracts
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: kaleido-io/contracts
           ref: keccak256
           path: contracts
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Build contracts
         working-directory: zeto/solidity
@@ -86,7 +90,7 @@ jobs:
           tar -czvf $ARTIFACTS_ROOT/zeto-contracts.tar.gz artifacts/contracts artifacts/@iden3
 
       - name: Publish Release Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: zeto-wasm-and-proving-keys
           path: |
@@ -105,9 +109,9 @@ jobs:
     steps:
       - name: Download Artifacts
         id: download
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       - name: Release Zeto Version
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         with:
           allowUpdates: 'true'
           artifacts: zeto-wasm-and-proving-keys/*.tar.gz

--- a/go-sdk/src/go.mod
+++ b/go-sdk/src/go.mod
@@ -2,8 +2,6 @@ module github.com/LFDT-Paladin/zeto/go-sdk
 
 go 1.25.0
 
-toolchain go1.25.3
-
 require (
 	github.com/LFDT-Paladin/smt v0.2.0
 	github.com/stretchr/testify v1.11.1

--- a/go-sdk/src/go.sum
+++ b/go-sdk/src/go.sum
@@ -231,8 +231,6 @@ github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaO
 github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=
 github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
-github.com/mattn/go-isatty v0.0.21 h1:xYae+lCNBP7QuW4PUnNG61ffM4hVIfm+zUzDuSzYLGs=
-github.com/mattn/go-isatty v0.0.21/go.mod h1:ZXfXG4SQHsB/w3ZeOYbR0PrPwLy+n6xiMrJlRFqopa4=
 github.com/mattn/go-isatty v0.0.22 h1:j8l17JJ9i6VGPUFUYoTUKPSgKe/83EYU2zBC7YNKMw4=
 github.com/mattn/go-isatty v0.0.22/go.mod h1:ZXfXG4SQHsB/w3ZeOYbR0PrPwLy+n6xiMrJlRFqopa4=
 github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0 h1:jWpvCLoY8Z/e3VKvlsiIGKtc+UG6U5vzxaoagmhXfyg=

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/hyperledger-labs/zeto
 
-go 1.22.5
+go 1.25.0


### PR DESCRIPTION
hore: add grouped dependabot config

Update actions/checkout to v7.0.0 and actions/setup-go to v6.5.0 across
all workflows. Add .github/dependabot.yml grouping updates per ecosystem
(github-actions, gomod, npm).

chore: Align go directives to 1.25.0

Bump the root module's go directive from 1.22.5 to 1.25.0 and drop the
stray toolchain pin in go-sdk/src so all modules target a consistent
1.25.0 floor. (integration-test stays at 1.25.7 due to a dependency
requirement.)